### PR TITLE
Remove public read header

### DIFF
--- a/src/helpers/web.js
+++ b/src/helpers/web.js
@@ -25,7 +25,6 @@ async function uploadToCodecovPUT(uploadURL, uploadFile) {
       .send(uploadFile) // sends a JSON post body
       .set("Content-Type", "application/x-gzip")
       .set("Content-Encoding", "gzip")
-      .set("x-amz-acl", "public-read")
       .set("Content-Length", Buffer.byteLength(uploadFile));
 
     if (result.status === 200) {


### PR DESCRIPTION
Changes to codecov's uploading infrastructure mean the public-read header is no longer required.