### PR TITLE
chore: pin version of pkg for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,11 @@
   ],
   "reviewers": [
     "codecov/open-source"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["pkg"],
+      "allowedVersions": "4.4.8"
+    }
   ]
 }


### PR DESCRIPTION
pkg 4.5.x will not correctly build node static on alpine.

https://github.com/codecov/uploader/issues/72 opened to investigate. Pinning for now.