### PR TITLE
chore: pin yargs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,10 @@
     {
       "matchPackageNames": ["pkg"],
       "allowedVersions": "4.4.8"
+    },
+    {
+      "matchPackageNames": ["yargs"],
+      "allowedVersions": "<17"
     }
   ]
 }


### PR DESCRIPTION
Yargs version 17 is not supported by node v10: #74