### PR TITLE
ci: upgrade node build version to 12.16.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
   build-linux-and-osx:
     docker:
       # specify the version you desire here
-      - image: circleci/node:10.24.1
+      - image: circleci/node:12.16.1
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -188,7 +188,7 @@ jobs:
   test-linux:
     docker:
       # specify the version you desire here
-      - image: circleci/node:10.24.1
+      - image: circleci/node:12.16.1
     steps:
       - checkout
       - attach_workspace:
@@ -214,7 +214,7 @@ jobs:
 
   test-linux-without-git:
     docker:
-      - image: circleci/node:10.24.1
+      - image: circleci/node:12.16.1
     steps:
       - attach_workspace:
           # TODO: Determine why we use the cwd on Linex and not on other operating systems.
@@ -331,7 +331,7 @@ jobs:
 
   review:
     docker:
-      - image: circleci/node:10.24.1
+      - image: circleci/node:12.16.1
     steps:
       - attach_workspace:
           at: .
@@ -362,7 +362,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/node:10.24.1
+      - image: circleci/node:12.16.1
     steps:
       - attach_workspace:
           at: .


### PR DESCRIPTION
Upgrade the version of Node that Linux and OSX are built in to 12.16.1, to match the alpine version.