### PR TITLE
Coverage directory -s

### DIFF
--- a/bin/codecov
+++ b/bin/codecov
@@ -43,6 +43,10 @@ var argv = require("yargs") // eslint-disable-line
       alias: "P",
       description: "Specify the pull request number mannually"
     },
+    dir: {
+      alias: "s",
+      description: "Directory to search for coverage reports.\nAlready searches project root and current working directory"
+    },
     token: {
       alias: "t",
       default: "",

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ function dryRun (uploadHost, token, query, uploadFile) {
  * @param {Object} args
  * @param {string} args.build Specify the build number manually
  * @param {string} args.branch Specify the branch manually
+ * @param {string} args.dir Directory to search for coverage reports.
  * @param {string} args.env Specify environment variables to be included with this build
  * @param {string} args.sha Specify the commit SHA mannually
  * @param {string} args.file Target file(s) to upload
@@ -82,7 +83,7 @@ async function main (args) {
     let coverageFilePaths = []
     if (!args.file) {
       coverageFilePaths = fileHelpers.getCoverageFiles(
-        projectRoot,
+        args.dir || projectRoot,
         // TODO: Determine why this is so slow (I suspect it's walking paths it should not)
         fileHelpers.coverageFilePatterns()
       )
@@ -117,7 +118,7 @@ async function main (args) {
     for (let index = 0; index < coverageFilePaths.length; index++) {
       const coverageFile = coverageFilePaths[index]
       const fileContents = await fileHelpers.readCoverageFile(
-        '.',
+        args.dir || projectRoot,
         coverageFile
       )
       uploadFile = uploadFile.concat(fileHelpers.fileHeader(coverageFile))

--- a/test/fixtures/coverage.txt
+++ b/test/fixtures/coverage.txt
@@ -1,0 +1,1 @@
+An example coverage file

--- a/test/fixtures/coverage.txt
+++ b/test/fixtures/coverage.txt
@@ -1,1 +1,1 @@
-An example coverage file
+An example coverage root file

--- a/test/fixtures/other/coverage.txt
+++ b/test/fixtures/other/coverage.txt
@@ -1,0 +1,1 @@
+An example coverage other file

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -109,4 +109,29 @@ describe('Uploader Core', function () {
     })
     expect(result).toEqual({ status: 'success', resultURL: 'https://results.codecov.io' })
   }, 30000)
+
+  it('Can find coverage from root dir', async function () {
+    jest.spyOn(process, 'exit').mockImplementation(() => {})
+    const log = jest.spyOn(console, 'log')
+    await app.main({
+      name: 'customname',
+      token: 'abcdefg',
+      url: 'https://codecov.io',
+      dryRun: true,
+    })
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/cobertura-coverage.xml/))
+  })
+
+  it('Can find coverage from custom dir', async function () {
+    jest.spyOn(process, 'exit').mockImplementation(() => {})
+    const log = jest.spyOn(console, 'log')
+    await app.main({
+      name: 'customname',
+      token: 'abcdefg',
+      url: 'https://codecov.io',
+      dryRun: true,
+      dir: './test/fixtures'
+    })
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/An example coverage file/))
+  })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -110,7 +110,7 @@ describe('Uploader Core', function () {
     expect(result).toEqual({ status: 'success', resultURL: 'https://results.codecov.io' })
   }, 30000)
 
-  it('Can find coverage from root dir', async function () {
+  it('Can find all coverage from root dir', async function () {
     jest.spyOn(process, 'exit').mockImplementation(() => {})
     const log = jest.spyOn(console, 'log')
     await app.main({
@@ -119,10 +119,11 @@ describe('Uploader Core', function () {
       url: 'https://codecov.io',
       dryRun: true,
     })
-    expect(log).toHaveBeenCalledWith(expect.stringMatching(/cobertura-coverage.xml/))
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/An example coverage root file/))
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/An example coverage other file/))
   })
 
-  it('Can find coverage from custom dir', async function () {
+  it('Can find only coverage from custom dir', async function () {
     jest.spyOn(process, 'exit').mockImplementation(() => {})
     const log = jest.spyOn(console, 'log')
     await app.main({
@@ -130,8 +131,9 @@ describe('Uploader Core', function () {
       token: 'abcdefg',
       url: 'https://codecov.io',
       dryRun: true,
-      dir: './test/fixtures'
+      dir: './test/fixtures/other'
     })
-    expect(log).toHaveBeenCalledWith(expect.stringMatching(/An example coverage file/))
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/An example coverage other file/))
+    expect(log).not.toHaveBeenCalledWith(expect.stringMatching(/An example coverage root file/))
   })
 })


### PR DESCRIPTION
-s flag to load files from a specified coverage directory instead of from project root.