### PR TITLE
ci: build node on alpine using prebuilt binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,7 @@ jobs:
           name: Download prebuilt static node binary
           command: |
             apk add wget
-            wget wget
-            https://github.com/codecov/node-static-alpine/releases/download/node.v14.16.1_0b668b007c0533fa4be1b24c66941a06f5965fdf/node
+            wget https://github.com/codecov/node-static-alpine/releases/download/node.v14.16.1_0b668b007c0533fa4be1b24c66941a06f5965fdf/node
 
       - run:
           name: Confirm that alpine node binary is static

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,53 +65,32 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - run:
-          name: Install dependencies for building a static copy of NodeJS
-          command: |
-            apk update
-            apk add git python3 openssh g++ make openssl linux-headers python2 npm patch
       - checkout
       - attach_workspace:
          # Must be absolute path or relative path from working_directory
           at: .
+          
       - run:
-          name: Clone nodejs repo
+          name: Download prebuilt static node binary
           command: |
-            git clone https://github.com/nodejs/node.git
-      - run:
-          name: Checkout v14.16.1 tag and apply patches
-          command: |
-            git fetch --all --tags
-            git checkout tags/v14.16.1 -b build
-            patch -p1 -i ../patches/node.v14.16.1.cpp.patch
-          working_directory: node
-
-      - run:
-          name: Configure NodeJS build for static
-          command: ./configure --fully-static
-          working_directory: node
-
-      - run:
-          name: Build static nodejs binary
-          command: make -j4
-          working_directory: node
+            apk add wget
+            wget wget
+            https://github.com/codecov/node-static-alpine/releases/download/node.v14.16.1_0b668b007c0533fa4be1b24c66941a06f5965fdf/node
 
       - run:
           name: Confirm that alpine node binary is static
           command: |
             apk add file
-            file out/Release/node
-          working_directory: node
+            file node
 
       - run:
           name: Create pkg-cache directory and copy static NodeJS binary
           command: |
             mkdir -p ~/.pkg-cache/v2.6
-            cp out/Release/node /root/.pkg-cache/v2.6/fetched-v14.0.0-alpine-x64
-          working_directory: node
+            cp node /root/.pkg-cache/v2.6/fetched-v14.0.0-alpine-x64
 
       - run:
-          name: Remove build dir and run tests
+          name: Remove downloaded binary and run tests
           command: |
             rm -rf node
             npm ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ jobs:
           name: Remove downloaded binary and run tests
           command: |
             rm -rf node
+            apk add npm
             npm ci
             npm test
             mkdir -p coverage-alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
           name: Remove downloaded binary and run tests
           command: |
             rm -rf node
-            apk add npm
+            apk add npm git
             npm ci
             npm test
             mkdir -p coverage-alpine


### PR DESCRIPTION
This should drastically cut down the build time since we are using the prebuilt binary from https://github.com/codecov/node-static-alpine/releases/tag/node.v14.16.1_0b668b007c0533fa4be1b24c66941a06f5965fdf instead of building node on each run.