### PR TITLE
ci: change pipeline to deploy on release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -437,10 +437,10 @@ workflows:
             - review
           filters:
             branches:
-              only: master
+              only: release 
       - release:
           requires:
             - deploy
           filters:
             branches:
-              only: master
+              only: release


### PR DESCRIPTION
We should deploy only on the `release` branch. The PRs to this branch should list a changelog, as I believe that will be the content of the release on GitHub.