### PR TITLE
Causes the correct server URL to be set in GitHub Actions.

### DIFF
--- a/src/ci_providers/provider_githubactions.js
+++ b/src/ci_providers/provider_githubactions.js
@@ -13,7 +13,7 @@ function _getBuild (inputs) {
 function _getBuildURL (inputs) {
   const { args, envs } = inputs
   return encodeURIComponent(
-    `https://github.com/${_getSlug(inputs)}/actions/runs/${_getBuild(inputs)}`
+    `https://${envs.GITHUB_SERVER_URL}/${_getSlug(inputs)}/actions/runs/${_getBuild(inputs)}`
   )
 }
 


### PR DESCRIPTION
Signed-off-by: Debayan De <debayande@users.noreply.github.com>

In its current form, the CodeCov uploader sets the domain name in the GitHub build URL as `github.com`. While this works fine for GitHub.com, it probably won't when run on GitHub Enterprise, GitHub's self-hosted sibling.

This patch, if applied, will fix the aforementioned issue (also filed as https://github.com/codecov/codecov-bash/issues/440 in [codecov/codecov-bash](https://github.com/codecov/codecov-bash)).