### PR TITLE
chore: send upload token as header vs. url param

### DIFF
--- a/src/helpers/web.js
+++ b/src/helpers/web.js
@@ -63,12 +63,13 @@ async function uploadToCodecov (uploadURL, token, query, uploadFile, version) {
   try {
     const result = await superagent
       .post(
-        `${uploadURL}/upload/v4?package=uploader-${version}&token=${token}&${query}`
+        `${uploadURL}/upload/v4?package=uploader-${version}&${query}`
       )
       .retry()
       .send(uploadFile) // sends a JSON post body
       .set('X-Reduced-Redundancy', 'false')
       .set('X-Content-Type', 'application/x-gzip')
+      .set('X-Upload-Token', token)
 
     return result.res.text
   } catch (error) {


### PR DESCRIPTION
We now want to send token as a header vs. URL param for security purposes.  Same as was done in https://github.com/codecov/codecov-bash/pull/439