### PR TITLE
Update to Cloud SDK and GitHub Actions support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ jobs:
             - release_tag
   release:
     docker:
-      - image: google/cloud-sdk:343.0.0-slim
+      - image: google/cloud-sdk:344.0.0-slim
     steps:
       - attach_workspace:
           # Must be absolute path or relative path from working_directory

--- a/src/ci_providers/provider_githubactions.js
+++ b/src/ci_providers/provider_githubactions.js
@@ -13,7 +13,7 @@ function _getBuild (inputs) {
 function _getBuildURL (inputs) {
   const { args, envs } = inputs
   return encodeURIComponent(
-    `https://github.com/${_getSlug(inputs)}/actions/runs/${_getBuild(inputs)}`
+    `${envs.GITHUB_SERVER_URL}/${_getSlug(inputs)}/actions/runs/${_getBuild(inputs)}`
   )
 }
 

--- a/test/providers/provider_githubactions.test.js
+++ b/test/providers/provider_githubactions.test.js
@@ -66,6 +66,7 @@ describe('GitHub Actions Params', () => {
         GITHUB_REF: 'refs/heads/master',
         GITHUB_REPOSITORY: 'testOrg/testRepo',
         GITHUB_RUN_ID: 2,
+        GITHUB_SERVER_URL: 'https://github.com',
         GITHUB_SHA: 'testingsha',
         GITHUB_WORKFLOW: 'testWorkflow',
       }
@@ -93,6 +94,7 @@ describe('GitHub Actions Params', () => {
         GITHUB_REF: 'refs/pull/1/merge',
         GITHUB_REPOSITORY: 'testOrg/testRepo',
         GITHUB_RUN_ID: 2,
+        GITHUB_SERVER_URL: 'https://github.com',
         GITHUB_SHA: 'testingsha',
         GITHUB_WORKFLOW: 'testWorkflow',
       }
@@ -125,6 +127,7 @@ describe('GitHub Actions Params', () => {
         GITHUB_REF: 'refs/pull/1/merge',
         GITHUB_REPOSITORY: 'testOrg/testRepo',
         GITHUB_RUN_ID: 2,
+        GITHUB_SERVER_URL: 'https://github.com',
         GITHUB_SHA: 'testingmergecommitsha',
         GITHUB_WORKFLOW: 'testWorkflow',
       }
@@ -159,6 +162,7 @@ describe('GitHub Actions Params', () => {
       },
       envs: {
         GITHUB_ACTIONS: true,
+        GITHUB_SERVER_URL: 'https://github.com',
       }
     }
     const expected = {
@@ -189,6 +193,7 @@ describe('GitHub Actions Params', () => {
         GITHUB_REF: 'refs/pull/1/merge',
         GITHUB_REPOSITORY: 'testOrg/testRepo',
         GITHUB_RUN_ID: 2,
+        GITHUB_SERVER_URL: 'https://github.com',
         GITHUB_SHA: 'testingsha',
         GITHUB_WORKFLOW: 'testWorkflow',
       }


### PR DESCRIPTION
chore(deps): update google/cloud-sdk docker tag to v344 (#127) …

chore: Causes the correct server URL to be set in GitHub Actions. (#131) …