### PR TITLE
test: exclude codecov.exe on windows

### DIFF
--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -22,7 +22,7 @@ function manualBlacklist () {
     '.nyc_output',
     '.circleci',
     '.nvmrc',
-    '.gitignore'
+    '.gitignore',
   ]
 }
 
@@ -133,7 +133,7 @@ function coverageFilePatterns () {
     'jacoco*.xml',
     'clover.xml',
     'report.xml',
-    '*.codecov.*',
+    '*.codecov.!(exe)',
     'codecov.*',
     'cobertura.xml',
     'excoveralls.json',
@@ -147,7 +147,7 @@ function coverageFilePatterns () {
     'cover.out',
     'gcov.info',
     '*.gcov',
-    '*.lst'
+    '*.lst',
   ]
 }
 

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -134,7 +134,7 @@ function coverageFilePatterns () {
     'clover.xml',
     'report.xml',
     '*.codecov.!(exe)',
-    'codecov.*',
+    'codecov.!(exe)',
     'cobertura.xml',
     'excoveralls.json',
     'luacov.report.out',

--- a/test/dummy.codecov.exe
+++ b/test/dummy.codecov.exe
@@ -1,0 +1,1 @@
+I'm not really an exe ;)

--- a/test/helpers/files.test.js
+++ b/test/helpers/files.test.js
@@ -75,6 +75,10 @@ describe('File Helpers', () => {
         'dummy.codecov.exe'
       )
 
+      expect(results).not.toContain(
+        'codecov.exe'
+      )
+
       expect(results).toContain(
         'test/fixtures/other/fake.codecov.txt'
       )

--- a/test/helpers/files.test.js
+++ b/test/helpers/files.test.js
@@ -4,6 +4,7 @@ const td = require('testdouble')
 const fs = require('fs')
 const childProcess = require('child_process')
 const fileHelpers = require('../../src/helpers/files')
+const { notDeepEqual } = require('assert')
 
 describe('File Helpers', () => {
   afterEach(function () {
@@ -66,7 +67,20 @@ describe('File Helpers', () => {
       )
       expect(reportContents).toBe('I am test coverage data')
     })
+
     it('can return a list of coverage files', () => {
+      const results = fileHelpers.getCoverageFiles('.', fileHelpers.coverageFilePatterns())
+
+      expect(results).not.toContain(
+        'dummy.codecov.exe'
+      )
+
+      expect(results).toContain(
+        'test/fixtures/other/fake.codecov.txt'
+      )
+    })
+
+    it('can return a list of coverage files with a pattern', () => {
       expect(
         fileHelpers.getCoverageFiles('.', ['index.test.js'])
       ).toStrictEqual(['test/index.test.js', 'test/providers/index.test.js'])


### PR DESCRIPTION
This fixes an issue where codecov.exe would attempt to upload itself on Windows, and the report processing would fail due to it being a binary.