### PR TITLE
Correct Windows uploads and enable GitHub Actions support on GHE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ jobs:
             - release_tag
   release:
     docker:
-      - image: google/cloud-sdk:343.0.0-slim
+      - image: google/cloud-sdk:344.0.0-slim
     steps:
       - attach_workspace:
           # Must be absolute path or relative path from working_directory

--- a/src/ci_providers/provider_githubactions.js
+++ b/src/ci_providers/provider_githubactions.js
@@ -13,7 +13,7 @@ function _getBuild (inputs) {
 function _getBuildURL (inputs) {
   const { args, envs } = inputs
   return encodeURIComponent(
-    `https://github.com/${_getSlug(inputs)}/actions/runs/${_getBuild(inputs)}`
+    `${envs.GITHUB_SERVER_URL}/${_getSlug(inputs)}/actions/runs/${_getBuild(inputs)}`
   )
 }
 

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -22,7 +22,7 @@ function manualBlacklist () {
     '.nyc_output',
     '.circleci',
     '.nvmrc',
-    '.gitignore'
+    '.gitignore',
   ]
 }
 
@@ -133,8 +133,8 @@ function coverageFilePatterns () {
     'jacoco*.xml',
     'clover.xml',
     'report.xml',
-    '*.codecov.*',
-    'codecov.*',
+    '*.codecov.!(exe)',
+    'codecov.!(exe)',
     'cobertura.xml',
     'excoveralls.json',
     'luacov.report.out',
@@ -147,7 +147,7 @@ function coverageFilePatterns () {
     'cover.out',
     'gcov.info',
     '*.gcov',
-    '*.lst'
+    '*.lst',
   ]
 }
 

--- a/src/helpers/web.js
+++ b/src/helpers/web.js
@@ -63,12 +63,13 @@ async function uploadToCodecov (uploadURL, token, query, uploadFile, version) {
   try {
     const result = await superagent
       .post(
-        `${uploadURL}/upload/v4?package=uploader-${version}&token=${token}&${query}`
+        `${uploadURL}/upload/v4?package=uploader-${version}&${query}`
       )
       .retry()
       .send(uploadFile) // sends a JSON post body
       .set('X-Reduced-Redundancy', 'false')
       .set('X-Content-Type', 'application/x-gzip')
+      .set('X-Upload-Token', token)
 
     return result.res.text
   } catch (error) {

--- a/test/dummy.codecov.exe
+++ b/test/dummy.codecov.exe
@@ -1,0 +1,1 @@
+I'm not really an exe ;)

--- a/test/helpers/files.test.js
+++ b/test/helpers/files.test.js
@@ -66,7 +66,24 @@ describe('File Helpers', () => {
       )
       expect(reportContents).toBe('I am test coverage data')
     })
+
     it('can return a list of coverage files', () => {
+      const results = fileHelpers.getCoverageFiles('.', fileHelpers.coverageFilePatterns())
+
+      expect(results).not.toContain(
+        'dummy.codecov.exe'
+      )
+
+      expect(results).not.toContain(
+        'codecov.exe'
+      )
+
+      expect(results).toContain(
+        'test/fixtures/other/fake.codecov.txt'
+      )
+    })
+
+    it('can return a list of coverage files with a pattern', () => {
       expect(
         fileHelpers.getCoverageFiles('.', ['index.test.js'])
       ).toStrictEqual(['test/index.test.js', 'test/providers/index.test.js'])

--- a/test/providers/provider_githubactions.test.js
+++ b/test/providers/provider_githubactions.test.js
@@ -66,6 +66,7 @@ describe('GitHub Actions Params', () => {
         GITHUB_REF: 'refs/heads/master',
         GITHUB_REPOSITORY: 'testOrg/testRepo',
         GITHUB_RUN_ID: 2,
+        GITHUB_SERVER_URL: 'https://github.com',
         GITHUB_SHA: 'testingsha',
         GITHUB_WORKFLOW: 'testWorkflow',
       }
@@ -93,6 +94,7 @@ describe('GitHub Actions Params', () => {
         GITHUB_REF: 'refs/pull/1/merge',
         GITHUB_REPOSITORY: 'testOrg/testRepo',
         GITHUB_RUN_ID: 2,
+        GITHUB_SERVER_URL: 'https://github.com',
         GITHUB_SHA: 'testingsha',
         GITHUB_WORKFLOW: 'testWorkflow',
       }
@@ -125,6 +127,7 @@ describe('GitHub Actions Params', () => {
         GITHUB_REF: 'refs/pull/1/merge',
         GITHUB_REPOSITORY: 'testOrg/testRepo',
         GITHUB_RUN_ID: 2,
+        GITHUB_SERVER_URL: 'https://github.com',
         GITHUB_SHA: 'testingmergecommitsha',
         GITHUB_WORKFLOW: 'testWorkflow',
       }
@@ -159,6 +162,7 @@ describe('GitHub Actions Params', () => {
       },
       envs: {
         GITHUB_ACTIONS: true,
+        GITHUB_SERVER_URL: 'https://github.com',
       }
     }
     const expected = {
@@ -189,6 +193,7 @@ describe('GitHub Actions Params', () => {
         GITHUB_REF: 'refs/pull/1/merge',
         GITHUB_REPOSITORY: 'testOrg/testRepo',
         GITHUB_RUN_ID: 2,
+        GITHUB_SERVER_URL: 'https://github.com',
         GITHUB_SHA: 'testingsha',
         GITHUB_WORKFLOW: 'testWorkflow',
       }


### PR DESCRIPTION
* chore(deps): update google/cloud-sdk docker tag to v344 (#127) …
* chore: Send upload token as header vs. URL param (#132) ...
* fix: Causes the correct server URL to be set in GitHub Actions. (#131) …
* fix: exclude codecov.exe on windows (#134) …