### PR TITLE
refactor: update to use spawnsync

### DIFF
--- a/src/ci_providers/provider_azurepipelines.js
+++ b/src/ci_providers/provider_azurepipelines.js
@@ -57,9 +57,10 @@ function _getSHA(inputs) {
 
   if (_getPR(inputs)) {
     const mergeCommitRegex = /^[a-z0-9]{40} [a-z0-9]{40}$/
-    const mergeCommitMessage = childProcess.execSync(
-      'git show --no-patch --format="%P"',
-    )
+    const mergeCommitMessage = childProcess
+      .spawnSync('git', ['show', '--no-patch', '--format="%P"'])
+      .stdout.toString()
+      .trimRight()
     if (mergeCommitRegex.exec(mergeCommitMessage)) {
       const mergeCommit = mergeCommitMessage.split(' ')[1]
       log(`    Fixing merge commit SHA ${commit} -> ${mergeCommit}`)

--- a/src/ci_providers/provider_azurepipelines.js
+++ b/src/ci_providers/provider_azurepipelines.js
@@ -58,8 +58,8 @@ function _getSHA(inputs) {
   if (_getPR(inputs)) {
     const mergeCommitRegex = /^[a-z0-9]{40} [a-z0-9]{40}$/
     const mergeCommitMessage = childProcess
-      .spawnSync('git', ['show', '--no-patch', '--format="%P"'])
-      .stdout.toString()
+      .execFileSync('git', ['show', '--no-patch', '--format="%P"'])
+      .toString()
       .trimRight()
     if (mergeCommitRegex.exec(mergeCommitMessage)) {
       const mergeCommit = mergeCommitMessage.split(' ')[1]

--- a/src/ci_providers/provider_githubactions.js
+++ b/src/ci_providers/provider_githubactions.js
@@ -64,9 +64,10 @@ function _getSHA(inputs) {
   let commit = envs.GITHUB_SHA
   if (pr && pr !== false && !args.sha) {
     const mergeCommitRegex = /^[a-z0-9]{40} [a-z0-9]{40}$/
-    const mergeCommitMessage = childProcess.execSync(
-      'git show --no-patch --format="%P"',
-    )
+    const mergeCommitMessage = childProcess
+      .spawnSync('git', ['show', '--no-patch', '--format="%P"'])
+      .stdout.toString()
+      .trimRight()
     if (mergeCommitRegex.exec(mergeCommitMessage)) {
       const mergeCommit = mergeCommitMessage.split(' ')[1]
       log(`    Fixing merge commit SHA ${commit} -> ${mergeCommit}`)

--- a/src/helpers/git.js
+++ b/src/helpers/git.js
@@ -24,9 +24,21 @@ function parseSlug(slug) {
 function parseSlugFromRemoteAddr(remoteAddr) {
   let slug = ''
   if (!remoteAddr) {
-    remoteAddr = childProcess.execSync(
-      "git config --get remote.origin.url || hg paths default || echo ''",
-    )
+    remoteAddr = childProcess
+      .spawnSync('git', [
+        'config',
+        '--get',
+        'remote.origin.url',
+        '||',
+        'hg',
+        'paths',
+        'default',
+        '||',
+        'echo',
+        "''",
+      ])
+      .stdout.toString()
+      .trimRight()
   }
   if (remoteAddr) {
     slug = parseSlug(remoteAddr)

--- a/src/helpers/validate.js
+++ b/src/helpers/validate.js
@@ -9,7 +9,7 @@ function validateURL(url) {
 }
 
 function validateFlags(flags) {
-  const mask = /^[\w\.\-]{1,45}$/
+  const mask = /^[\w.-]{1,45}$/
   return mask.test(flags)
 }
 

--- a/src/helpers/validate.js
+++ b/src/helpers/validate.js
@@ -9,7 +9,7 @@ function validateURL(url) {
 }
 
 function validateFlags(flags) {
-  const mask = /^[\w.-]{1,45}$/
+  const mask = /^[\w\.\-]{1,45}$/
   return mask.test(flags)
 }
 

--- a/test/providers/provider_azurepipelines.test.js
+++ b/test/providers/provider_azurepipelines.test.js
@@ -140,10 +140,13 @@ describe('Jenkins CI Params', () => {
       service: 'azure_pipelines',
       slug: '',
     }
-    const execSync = td.replace(childProcess, 'execSync')
-    td.when(execSync('git show --no-patch --format="%P"')).thenReturn(
-      'testingsha123456789012345678901234567890 testingmergecommitsha2345678901234567890',
-    )
+    const spawnSync = td.replace(childProcess, 'spawnSync')
+    td.when(
+      spawnSync('git', ['show', '--no-patch', '--format="%P"']),
+    ).thenReturn({
+      stdout:
+        'testingsha123456789012345678901234567890 testingmergecommitsha2345678901234567890',
+    })
     const params = providerAzurepipelines.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
   })

--- a/test/providers/provider_azurepipelines.test.js
+++ b/test/providers/provider_azurepipelines.test.js
@@ -140,13 +140,10 @@ describe('Jenkins CI Params', () => {
       service: 'azure_pipelines',
       slug: '',
     }
-    const spawnSync = td.replace(childProcess, 'spawnSync')
+    const execFileSync = td.replace(childProcess, 'execFileSync')
     td.when(
-      spawnSync('git', ['show', '--no-patch', '--format="%P"']),
-    ).thenReturn({
-      stdout:
-        'testingsha123456789012345678901234567890 testingmergecommitsha2345678901234567890',
-    })
+      execFileSync('git', ['show', '--no-patch', '--format="%P"']),
+    ).thenReturn('testingsha123456789012345678901234567890 testingmergecommitsha2345678901234567890')
     const params = providerAzurepipelines.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
   })

--- a/test/providers/provider_githubactions.test.js
+++ b/test/providers/provider_githubactions.test.js
@@ -112,10 +112,12 @@ describe('GitHub Actions Params', () => {
       slug: 'testOrg/testRepo',
     }
 
-    const execSync = td.replace(childProcess, 'execSync')
-    td.when(execSync('git show --no-patch --format="%P"')).thenReturn(
-      'testingsha',
-    )
+    const spawnSync = td.replace(childProcess, 'spawnSync')
+    td.when(
+      spawnSync('git', ['show', '--no-patch', '--format="%P"']),
+    ).thenReturn({
+      stdout: 'testingsha',
+    })
     const params = providerGitHubactions.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
   })
@@ -146,10 +148,13 @@ describe('GitHub Actions Params', () => {
       slug: 'testOrg/testRepo',
     }
 
-    const execSync = td.replace(childProcess, 'execSync')
-    td.when(execSync('git show --no-patch --format="%P"')).thenReturn(
-      'testingsha123456789012345678901234567890 testingmergecommitsha2345678901234567890',
-    )
+    const spawnSync = td.replace(childProcess, 'spawnSync')
+    td.when(
+      spawnSync('git', ['show', '--no-patch', '--format="%P"']),
+    ).thenReturn({
+      stdout:
+        'testingsha123456789012345678901234567890 testingmergecommitsha2345678901234567890',
+    })
     const params = providerGitHubactions.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
   })
@@ -180,8 +185,10 @@ describe('GitHub Actions Params', () => {
       slug: 'testOrg/testRepo',
     }
 
-    const execSync = td.replace(childProcess, 'execSync')
-    td.when(execSync('git show --no-patch --format="%P"')).thenReturn('testsha')
+    const spawnSync = td.replace(childProcess, 'spawnSync')
+    td.when(
+      spawnSync('git', ['show', '--no-patch', '--format="%P"']),
+    ).thenReturn({ stdout: 'testsha' })
     const params = providerGitHubactions.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
   })
@@ -212,8 +219,10 @@ describe('GitHub Actions Params', () => {
       slug: 'testOrg/testRepo',
     }
 
-    const execSync = td.replace(childProcess, 'execSync')
-    td.when(execSync('git show --no-patch --format="%P"')).thenReturn('')
+    const spawnSync = td.replace(childProcess, 'spawnSync')
+    td.when(
+      spawnSync('git', ['show', '--no-patch', '--format="%P"']),
+    ).thenReturn({ stdout: '' })
     const params = providerGitHubactions.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
   })

--- a/test/providers/provider_gitlabci.test.js
+++ b/test/providers/provider_gitlabci.test.js
@@ -118,7 +118,7 @@ describe('GitLabCI Params', () => {
       expect(params.slug).toBe('testOrg/testRepo')
     })
 
-    it('can get the slug from girl url', () => {
+    it('can get the slug from git url', () => {
       inputs.envs.CI_BUILD_REPO = 'git@gitlab.com:testOrg/testRepo.git'
       const params = providerGitLabci.getServiceParams(inputs)
       expect(params.slug).toBe('testOrg/testRepo')
@@ -126,12 +126,21 @@ describe('GitLabCI Params', () => {
 
     it('can get the slug from git config', () => {
       inputs.envs.CI_BUILD_REPO = ''
-      const execSync = td.replace(childProcess, 'execSync')
+      const spawnSync = td.replace(childProcess, 'spawnSync')
       td.when(
-        execSync(
-          "git config --get remote.origin.url || hg paths default || echo ''",
-        ),
-      ).thenReturn('https://gitlab.com/testOrg/testRepo.git')
+        spawnSync('git', [
+          'config',
+          '--get',
+          'remote.origin.url',
+          '||',
+          'hg',
+          'paths',
+          'default',
+          '||',
+          'echo',
+          "''",
+        ]),
+      ).thenReturn({ stdout: 'https://gitlab.com/testOrg/testRepo.git' })
 
       const params = providerGitLabci.getServiceParams(inputs)
       expect(params.slug).toBe('testOrg/testRepo')
@@ -139,12 +148,21 @@ describe('GitLabCI Params', () => {
 
     it('can get the slug from git config as /', () => {
       inputs.envs.CI_BUILD_REPO = ''
-      const execSync = td.replace(childProcess, 'execSync')
+      const spawnSync = td.replace(childProcess, 'spawnSync')
       td.when(
-        execSync(
-          "git config --get remote.origin.url || hg paths default || echo ''",
-        ),
-      ).thenReturn('git@gitlab.com:/')
+        spawnSync('git', [
+          'config',
+          '--get',
+          'remote.origin.url',
+          '||',
+          'hg',
+          'paths',
+          'default',
+          '||',
+          'echo',
+          "''",
+        ]),
+      ).thenReturn({ stdout: 'git@gitlab.com:/' })
 
       const params = providerGitLabci.getServiceParams(inputs)
       expect(params.slug).toBe('')
@@ -152,12 +170,21 @@ describe('GitLabCI Params', () => {
 
     it('can handle no remote origin url', () => {
       inputs.envs.CI_BUILD_REPO = ''
-      const execSync = td.replace(childProcess, 'execSync')
+      const spawnSync = td.replace(childProcess, 'spawnSync')
       td.when(
-        execSync(
-          "git config --get remote.origin.url || hg paths default || echo ''",
-        ),
-      ).thenReturn('')
+        spawnSync('git', [
+          'config',
+          '--get',
+          'remote.origin.url',
+          '||',
+          'hg',
+          'paths',
+          'default',
+          '||',
+          'echo',
+          "''",
+        ]),
+      ).thenReturn({ stdout: '' })
 
       const params = providerGitLabci.getServiceParams(inputs)
       expect(params.slug).toBe('')

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -1,4 +1,29 @@
 const td = require('testdouble')
+const childProcess = require('child_process')
+const { beforeAll, afterEach, afterAll, expect } = require('@jest/globals')
 
 // eslint-disable-next-line no-undef
 require('testdouble-jest')(td, jest)
+
+let execSync
+let exec
+
+beforeAll(() => {
+  execSync = jest.spyOn(childProcess, 'execSync').mockImplementation(() => {
+    throw new Error(
+      `Security alert! Do not use execSync(), use spawnSync() instead`,
+    )
+  })
+  exec = jest.spyOn(childProcess, 'exec').mockImplementation(() => {
+    throw new Error(`Security alert! Do not use exec(), use spawn() instead`)
+  })
+})
+
+afterEach(() => {
+  expect(execSync).not.toBeCalled()
+  expect(exec).not.toBeCalled()
+})
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})


### PR DESCRIPTION
* refactor: change exec Sync to use spawnSync. I believe this was part of the fix for Command Injection on codecov-node, can't confirm. @eddiemoore and @RA80533, would love your review.
* test: add test and alert for execSync use to test/test_helpers.js