### PR TITLE
ci: update to xcode 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
 
   test-macos:
     macos:
-      xcode: '10.0.0'
+      xcode: '12.5.1'
     steps:
       - checkout
       - attach_workspace:
@@ -245,7 +245,7 @@ jobs:
 
   test-macos-without-git:
     macos:
-      xcode: '10.0.0'
+      xcode: '12.5.1'
     steps:
       - attach_workspace:
           at: .


### PR DESCRIPTION
CircleCI is depreciating xcode 10
https://discuss.circleci.com/t/xcode-deprecation-notice-9-4-1-10-0-0-10-1-0-and-10-2-1/40515

Upgrading to latest stable per https://circleci.com/docs/2.0/testing-ios/