### PR TITLE
fix: Allow multiple files to be read

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,6 +105,7 @@ async function main(args) {
   // Look for files
   let coverageFilePaths = []
   if (!args.file) {
+    log('Searching for coverage files...')
     coverageFilePaths = fileHelpers.getCoverageFiles(
       args.dir || projectRoot,
       // TODO: Determine why this is so slow (I suspect it's walking paths it should not)
@@ -119,15 +120,15 @@ async function main(args) {
       )
     }
   } else {
-    if (typeof(args.file) === 'object') {
-      for (const file of args.file) {
-        coverageFilePaths.push(validateHelpers.validateFileNamePath(file) ? file : '')
-      }
+    if (typeof(args.file) === 'string') {
+      coverageFilePaths = [args.file]
     } else {
-      coverageFilePaths[0] = validateHelpers.validateFileNamePath(args.file)
-        ? args.file
-        : ''
+      coverageFilePaths = args.file
     }
+
+    coverageFilePaths.filter((file) => {
+      return validateHelpers.validateFileNamePath(file);
+    })
     if (coverageFilePaths.length === 0) {
       throw new Error('Not coverage file found, exiting.')
     }
@@ -141,12 +142,14 @@ async function main(args) {
   for (const coverageFile of coverageFilePaths) {
     let fileContents
     try {
+      log(`Processing ${coverageFile}...`),
       fileContents = await fileHelpers.readCoverageFile(
         args.dir || projectRoot,
         coverageFile,
       )
     } catch (error) {
-      throw new Error(`Error reading coverage file (${coverageFile}): ${error}`)
+      log(`Could not read coverage file (${coverageFile}): ${error}`)
+      continue;
     }
 
     uploadFile = uploadFile

--- a/src/index.js
+++ b/src/index.js
@@ -119,9 +119,15 @@ async function main(args) {
       )
     }
   } else {
-    coverageFilePaths[0] = validateHelpers.validateFileNamePath(args.file)
-      ? args.file
-      : ''
+    if (typeof(args.file) === 'object') {
+      for (const file of args.file) {
+        coverageFilePaths.push(validateHelpers.validateFileNamePath(file) ? file : '')
+      }
+    } else {
+      coverageFilePaths[0] = validateHelpers.validateFileNamePath(args.file)
+        ? args.file
+        : ''
+    }
     if (coverageFilePaths.length === 0) {
       throw new Error('Not coverage file found, exiting.')
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -133,6 +133,45 @@ describe('Uploader Core', () => {
     )
   })
 
+  it('Can find a single specified file', async () => {
+    jest.spyOn(process, 'exit').mockImplementation(() => {})
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+    await app.main({
+      dryRun: true,
+      file: 'test/fixtures/coverage.txt',
+      name: 'customname',
+      token: 'abcdefg',
+      url: 'https://codecov.io',
+    })
+    expect(log).toHaveBeenCalledWith(
+      expect.stringMatching("Processing test/fixtures/coverage.txt..."),
+    )
+  })
+
+  it('Can find multiple specified files', async () => {
+    jest.spyOn(process, 'exit').mockImplementation(() => {})
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+    await app.main({
+      dryRun: true,
+      file: ['test/fixtures/coverage.txt', 'test/fixtures/other/coverage.txt', 'test/does/not/exist.txt'],
+      name: 'customname',
+      token: 'abcdefg',
+      url: 'https://codecov.io',
+    })
+    expect(log).toHaveBeenCalledWith(
+      expect.stringMatching("Processing test/fixtures/coverage.txt..."),
+    )
+    expect(log).toHaveBeenCalledWith(
+      expect.stringMatching("Processing test/fixtures/coverage.txt..."),
+    )
+    expect(log).toHaveBeenCalledWith(
+      expect.stringMatching("Processing test/does/not/exist.txt..."),
+    )
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("Could not read coverage file (test/does/not/exist.txt):"),
+    )
+  })
+
   it('Can find only coverage from custom dir', async () => {
     jest.spyOn(process, 'exit').mockImplementation(() => {})
     const log = jest.spyOn(console, 'log').mockImplementation(() => {})


### PR DESCRIPTION
If multiple files are supplied to the uploader, it currently pushes all of them as the first element of an array e.g.

```
[
  [ first_file, second_file ]
]
```

This breaks the uploader's ability to read the files.