### PR TITLE
hotfix: validateToken needs to take in the token

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ async function main(args) {
   let token = validateHelpers.validateToken(args.token) ? args.token : ''
   if (token === '') {
     token = process.env.CODECOV_TOKEN || ''
-    token = validateHelpers.validateToken(process.env.CODECOV_TOKEN)
+    token = validateHelpers.validateToken(token)
       ? process.env.CODECOV_TOKEN
       : ''
   }


### PR DESCRIPTION
`process.env.CODECOV_TOKEN` can be `undefined` which will bork this call. It should be taking from `token` set earlier