### PR TITLE
Improve glob and file operations

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@types/glob": "7.1.4",
         "@types/jest": "26.0.24",
+        "@types/mock-fs": "4.13.1",
         "@types/node": "16.3.3",
         "@typescript-eslint/eslint-plugin": "4.28.4",
         "@typescript-eslint/parser": "4.28.4",
@@ -30,6 +31,7 @@
         "husky": "7.0.1",
         "jest": "27.0.6",
         "lint-staged": "11.0.1",
+        "mock-fs": "5.0.0",
         "nock": "13.1.1",
         "pkg": "5.1.0",
         "prettier": "2.3.2",
@@ -1445,6 +1447,15 @@
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
       "dev": true
+    },
+    "node_modules/@types/mock-fs": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.1.tgz",
+      "integrity": "sha512-m6nFAJ3lBSnqbvDZioawRvpLXSaPyn52Srf7OfzjubYbYX8MTUdIgDxQl0wEapm4m/pNYSd9TXocpQ0TvZFlYA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "16.3.3",
@@ -4871,6 +4882,12 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
+    "node_modules/mock-fs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.0.0.tgz",
+      "integrity": "sha512-A5mm/SpSDwwc/klSaEvvKMGQQtiGiQy8UcDAd/vpVO1fV+4zaHjt39yKgCSErFzv2zYxZIUx9Ud/7ybeHBf8Fg==",
+      "dev": true
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -7770,6 +7787,15 @@
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
       "dev": true
     },
+    "@types/mock-fs": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.1.tgz",
+      "integrity": "sha512-m6nFAJ3lBSnqbvDZioawRvpLXSaPyn52Srf7OfzjubYbYX8MTUdIgDxQl0wEapm4m/pNYSd9TXocpQ0TvZFlYA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "16.3.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.3.tgz",
@@ -10525,6 +10551,12 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
+    },
+    "mock-fs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.0.0.tgz",
+      "integrity": "sha512-A5mm/SpSDwwc/klSaEvvKMGQQtiGiQy8UcDAd/vpVO1fV+4zaHjt39yKgCSErFzv2zYxZIUx9Ud/7ybeHBf8Fg==",
       "dev": true
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@types/glob": "7.1.4",
     "@types/jest": "26.0.24",
+    "@types/mock-fs": "4.13.1",
     "@types/node": "16.3.3",
     "@typescript-eslint/eslint-plugin": "4.28.4",
     "@typescript-eslint/parser": "4.28.4",
@@ -45,6 +46,7 @@
     "husky": "7.0.1",
     "jest": "27.0.6",
     "lint-staged": "11.0.1",
+    "mock-fs": "5.0.0",
     "nock": "13.1.1",
     "pkg": "5.1.0",
     "prettier": "2.3.2",

--- a/test/benchmark.txt
+++ b/test/benchmark.txt
@@ -1,8 +1,0 @@
-2e3228a04bc8d14562d30098e4857dbdcd8270c5
-
-test/helpers/files.test.js
-
-Test Suites: 1 passed, 1 total
-Tests:       18 passed, 18 total
-Snapshots:   0 total
-Time:        19 s

--- a/test/benchmark.txt
+++ b/test/benchmark.txt
@@ -1,0 +1,8 @@
+2e3228a04bc8d14562d30098e4857dbdcd8270c5
+
+test/helpers/files.test.js
+
+Test Suites: 1 passed, 1 total
+Tests:       18 passed, 18 total
+Snapshots:   0 total
+Time:        19 s


### PR DESCRIPTION
Currently the ignore feature does not work, and the blacklist is static.
After adding test guards, will optimize directory searching and add ignore feature.

Related:
- #155 
- #98 
- #152 
- #36 