### PR TITLE
Remove extraneous `@ts-check` directives

### DIFF
--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -1,4 +1,3 @@
-// @ts-check
 const childProcess = require('child_process')
 const fs = require('fs')
 const glob = require('glob')

--- a/src/helpers/logger.js
+++ b/src/helpers/logger.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 /**
  *
  * @param {string} message

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-// @ts-check
 const zlib = require('zlib')
 const { version } = require('../package.json')
 const fileHelpers = require('./helpers/files')

--- a/test/helpers/logger.test.js
+++ b/test/helpers/logger.test.js
@@ -1,4 +1,3 @@
-// @ts-check
 const logger = require('../../src/helpers/logger')
 const { expect, it } = require('@jest/globals')
 


### PR DESCRIPTION
Instances of `@ts-check` override any project configuration of files containing the compiler directive. In other words, the compiler options derived from the root tsconfig.json file do not take effect in their entirety for any scripts that contain the `@ts-check` directive. A side effect of this interaction is that type definitions available through user-installed packages are not accessible in any scripts containing the compiler directive.

Fixes #248