### PR TITLE
fix: always pass pr to server as a number

### DIFF
--- a/src/ci_providers/provider_appveyorci.ts
+++ b/src/ci_providers/provider_appveyorci.ts
@@ -43,9 +43,9 @@ function _getJob(envs: UploaderEnvs) {
   return ''
 }
 
-function _getPR(inputs: UploaderInputs) {
+export function _getPR(inputs: UploaderInputs): number {
   const { args, envs } = inputs
-  return args.pr || envs.APPVEYOR_PULL_REQUEST_NUMBER || ''
+  return Number(args.pr || envs.APPVEYOR_PULL_REQUEST_NUMBER || '')
 }
 
 function _getService() {

--- a/src/ci_providers/provider_azurepipelines.ts
+++ b/src/ci_providers/provider_azurepipelines.ts
@@ -34,13 +34,13 @@ function _getJob(envs: UploaderEnvs): string {
   return envs.BUILD_BUILDID || ''
 }
 
-function _getPR(inputs: UploaderInputs): string {
+export function _getPR(inputs: UploaderInputs): number {
   const { args, envs } = inputs
   return (
-    args.pr ||
+    Number(args.pr ||
     envs.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER ||
     envs.SYSTEM_PULLREQUEST_PULLREQUESTID ||
-    ''
+    '')
   )
 }
 

--- a/src/ci_providers/provider_bitbucket.ts
+++ b/src/ci_providers/provider_bitbucket.ts
@@ -26,9 +26,9 @@ function _getJob(envs: UploaderEnvs): string {
   return envs.BITBUCKET_BUILD_NUMBER || ''
 }
 
-function _getPR(inputs: UploaderInputs): string {
+export function _getPR(inputs: UploaderInputs): number {
   const { args, envs } = inputs
-  return args.pr || envs.BITBUCKET_PR_ID || ''
+  return Number(args.pr || envs.BITBUCKET_PR_ID || '')
 }
 
 function _getService(): string {

--- a/src/ci_providers/provider_buildkite.ts
+++ b/src/ci_providers/provider_buildkite.ts
@@ -60,9 +60,9 @@ function _getJob(envs: UploaderEnvs): string {
  * @param {args: {}, envs: {}} inputs an object of arguments and enviromental variable key/value pairs
  * @returns {string}
  */
-function _getPR(inputs: UploaderInputs): string {
+export function _getPR(inputs: UploaderInputs): number {
   const { args } = inputs
-  return args.pr || ''
+  return Number(args.pr || '')
 }
 
 /**

--- a/src/ci_providers/provider_circleci.ts
+++ b/src/ci_providers/provider_circleci.ts
@@ -55,9 +55,9 @@ function _getBuild(inputs: UploaderInputs): string {
   return args.build || envs.CIRCLE_BUILD_NUM || ''
 }
 
-function _getPR(inputs: UploaderInputs): string {
+export function _getPR(inputs: UploaderInputs): number {
   const { args, envs } = inputs
-  return args.pr || envs.CIRCLE_PR_NUMBER || ''
+  return Number(args.pr || envs.CIRCLE_PR_NUMBER || '')
 }
 
 function _getJob(envs: UploaderEnvs): string {

--- a/src/ci_providers/provider_cirrus.ts
+++ b/src/ci_providers/provider_cirrus.ts
@@ -23,9 +23,9 @@ function _getJob(envs: UploaderEnvs): string {
   return envs.CIRRUS_TASK_ID || ''
 }
 
-function _getPR(inputs: UploaderInputs): string {
+export function _getPR(inputs: UploaderInputs): number {
   const { args, envs } = inputs
-  return args.pr || envs.CIRRUS_PR || ''
+  return Number(args.pr || envs.CIRRUS_PR || '')
 }
 
 function _getService(): string {

--- a/src/ci_providers/provider_codebuild.ts
+++ b/src/ci_providers/provider_codebuild.ts
@@ -28,15 +28,15 @@ function _getJob(envs: UploaderEnvs): string {
   return envs.CODEBUILD_BUILD_ID || ''
 }
 
-function _getPR(inputs: UploaderInputs): string {
+export function _getPR(inputs: UploaderInputs): number {
   const { args, envs } = inputs
   return (
-    args.pr ||
+    Number(args.pr ||
     (envs.CODEBUILD_SOURCE_VERSION &&
     envs.CODEBUILD_SOURCE_VERSION.startsWith('pr/')
       ? envs.CODEBUILD_SOURCE_VERSION.replace(/^pr\//, '')
       : '')
-  )
+  ))
 }
 
 function _getService(): string {

--- a/src/ci_providers/provider_drone.ts
+++ b/src/ci_providers/provider_drone.ts
@@ -24,9 +24,9 @@ function _getJob(envs: UploaderEnvs): string {
   return ''
 }
 
-function _getPR(inputs: UploaderInputs): string {
+export function _getPR(inputs: UploaderInputs): number {
   const { args, envs } = inputs
-  return args.pr || envs.DRONE_PULL_REQUEST || ''
+  return Number(args.pr || envs.DRONE_PULL_REQUEST || '')
 }
 
 function _getService(): string {

--- a/src/ci_providers/provider_githubactions.ts
+++ b/src/ci_providers/provider_githubactions.ts
@@ -40,7 +40,7 @@ function _getJob(envs: UploaderEnvs): string {
   return encodeURIComponent(envs.GITHUB_WORKFLOW || '')
 }
 
-function _getPR(inputs: UploaderInputs): string {
+export function _getPR(inputs: UploaderInputs): number {
   const { args, envs } = inputs
   let match
   if (envs.GITHUB_HEAD_REF && envs.GITHUB_HEAD_REF !== '') {
@@ -50,7 +50,7 @@ function _getPR(inputs: UploaderInputs): string {
       match = matches[1]
     }
   }
-  return args.pr || match || ''
+  return Number(args.pr || match || '')
 }
 
 function _getService(): string {
@@ -66,7 +66,7 @@ function _getSHA(inputs: UploaderInputs): string {
   const pr = _getPR(inputs)
 
   let commit = envs.GITHUB_SHA
-  if (pr && pr.toLowerCase() !== 'false' && !args.sha) {
+  if (pr && pr !== 0 && !args.sha) {
     const mergeCommitRegex = /^[a-z0-9]{40} [a-z0-9]{40}$/
     const mergeCommitMessage = childProcess
       .spawnSync('git', ['show', '--no-patch', '--format="%P"'])

--- a/src/ci_providers/provider_gitlabci.ts
+++ b/src/ci_providers/provider_gitlabci.ts
@@ -26,9 +26,9 @@ function _getJob(envs: UploaderEnvs): string {
   return ''
 }
 
-function _getPR(inputs: UploaderInputs): string {
+export function _getPR(inputs: UploaderInputs): number {
   const { args } = inputs
-  return args.pr || ''
+  return Number(args.pr || '')
 }
 
 function _getService(): string {

--- a/src/ci_providers/provider_jenkinsci.ts
+++ b/src/ci_providers/provider_jenkinsci.ts
@@ -31,9 +31,9 @@ function _getJob(envs: UploaderEnvs) {
   return ''
 }
 
-function _getPR(inputs: UploaderInputs): string {
+export function _getPR(inputs: UploaderInputs): number {
   const { args, envs } = inputs
-  return args.pr || envs.ghprbPullId || envs.CHANGE_ID || ''
+  return Number(args.pr || envs.ghprbPullId || envs.CHANGE_ID || '')
 }
 
 function _getService(): string {

--- a/src/ci_providers/provider_local.ts
+++ b/src/ci_providers/provider_local.ts
@@ -40,9 +40,9 @@ function _getJob(env: UploaderEnvs): string {
 }
 
 // eslint-disable-next-line no-unused-vars
-function _getPR(inputs: UploaderInputs): string {
+export function _getPR(inputs: UploaderInputs): number {
   const { args } = inputs
-  return args.pr || ''
+  return Number(args.pr || '')
 }
 
 // This is the value that gets passed to the Codecov uploader

--- a/src/ci_providers/provider_teamcity.ts
+++ b/src/ci_providers/provider_teamcity.ts
@@ -40,9 +40,9 @@ function _getBuild(inputs: UploaderInputs): string {
   return args.build || envs.BUILD_NUMBER || ''
 }
 
-function _getPR(inputs: UploaderInputs): string {
+export function _getPR(inputs: UploaderInputs): number {
   const { args } = inputs
-  return args.pr || ''
+  return Number(args.pr || '')
 }
 
 // eslint-disable-next-line no-unused-vars

--- a/src/ci_providers/provider_travisci.ts
+++ b/src/ci_providers/provider_travisci.ts
@@ -28,9 +28,9 @@ function _getJob(envs: UploaderEnvs): string {
   return envs.TRAVIS_JOB_ID || ''
 }
 
-function _getPR(inputs: UploaderInputs): string {
+export function _getPR(inputs: UploaderInputs): number {
   const { args, envs } = inputs
-  return args.pr || envs.TRAVIS_PULL_REQUEST || ''
+  return Number(args.pr || envs.TRAVIS_PULL_REQUEST || '')
 }
 
 function _getService(): string {

--- a/src/ci_providers/provider_wercker.ts
+++ b/src/ci_providers/provider_wercker.ts
@@ -25,9 +25,9 @@ function _getJob(envs: UploaderEnvs): string {
   return ''
 }
 
-function _getPR(inputs: UploaderInputs): string {
+export function _getPR(inputs: UploaderInputs): number {
   const { args } = inputs
-  return args.pr || ''
+  return Number(args.pr || '')
 }
 
 function _getService(): string {

--- a/src/helpers/validate.ts
+++ b/src/helpers/validate.ts
@@ -1,6 +1,7 @@
 import { UploaderArgs } from '../types'
 
 import validator from 'validator'
+import { logAndThrow } from './util'
 
 /**
  *
@@ -59,3 +60,10 @@ export function fetchToken(args: UploaderArgs): string {
   }
   return token
 }
+
+export function checkValueType(name: string, value: unknown, type: string): void {
+  if (typeof value !== type) {
+    return logAndThrow(`The value of ${name} is not of type ${type}, can not continue, please review: ${value}`)
+  }
+}
+

--- a/src/helpers/web.ts
+++ b/src/helpers/web.ts
@@ -5,6 +5,7 @@ import { version } from '../../package.json'
 import * as validateHelpers from './validate'
 import { info, logError } from './logger'
 import { logAndThrow } from './util'
+import { checkValueType } from './validate'
 
 /**
  *
@@ -132,7 +133,12 @@ function camelToSnake(str: string): string {
  * @returns {string}
  */
 export function generateQuery(queryParams: IServiceParams): string {
+  checkValueType('pr', queryParams.pr, 'number')
+  if (queryParams.pr === 0) {
+    queryParams.pr = ''
+  }
   return Object.entries(queryParams)
     .map(([key, value]) => `${camelToSnake(key)}=${value}`)
     .join('&')
 }
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,6 @@ export interface UploaderInputs {
 
 export interface IProvider {
   detect: (arg0: UploaderEnvs) => boolean
-  _getPR (arg0: UploaderInputs): number
   getServiceName: () => string
   getServiceParams: (arg0: UploaderInputs) => IServiceParams
   getEnvVarNames: () => string[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export interface UploaderInputs {
 
 export interface IProvider {
   detect: (arg0: UploaderEnvs) => boolean
+  _getPR (arg0: UploaderInputs): number
   getServiceName: () => string
   getServiceParams: (arg0: UploaderInputs) => IServiceParams
   getEnvVarNames: () => string[]
@@ -42,7 +43,7 @@ export interface IServiceParams {
   buildURL: string
   commit: string
   job: string
-  pr: string
+  pr: number | ''
   service: string
   slug: string
   name?: string

--- a/test/helpers/validate.test.ts
+++ b/test/helpers/validate.test.ts
@@ -1,9 +1,16 @@
 import * as validate from '../../src/helpers/validate'
+import { checkValueType } from '../../src/helpers/validate'
 
 // Backup the env
 const realEnv = { ...process.env }
 
 describe('Input Validators', () => {
+  describe('checkValueType()', () => {
+it('throws an error when the value is not the correct type', () => {
+  expect(() => { checkValueType('testValue', {}, 'number')}).toThrowError(/The value of testValue is not of type number, can not continue, please review/)
+})
+  })
+
   describe('Tokens', () => {
     it('Returns true with a valid alphanumeric token', () => {
       expect(validate.validateToken('1bc123')).toBe(true)

--- a/test/helpers/web.test.ts
+++ b/test/helpers/web.test.ts
@@ -74,7 +74,7 @@ describe('Web Helpers', () => {
   })
 
   it('Can generate query URL', () => {
-    const queryParams = {
+    const queryParams: IServiceParams  = {
       branch: 'testBranch',
       commit: 'commitSHA',
       build: '4',
@@ -84,7 +84,7 @@ describe('Web Helpers', () => {
       slug: 'testOrg/testRepo',
       service: 'testingCI',
       flags: 'unit,uploader',
-      pr: '2',
+      pr: 2,
       job: '6',
     }
     expect(webHelper.generateQuery(queryParams)).toBe(
@@ -105,7 +105,7 @@ describe('Web Helpers', () => {
         job: '',
         service: 'Testing',
         slug: '',
-        pr: '',
+        pr: 0,
       },
     )
     expect(result.flags).toBe('testFlag')
@@ -124,7 +124,7 @@ describe('Web Helpers', () => {
         job: '',
         service: 'Testing',
         slug: '',
-        pr: '',
+        pr: 0,
       },
     )
     expect(result.flags).toBe('testFlag1,testFlag2')

--- a/test/providers/provider_appveyorci.test.ts
+++ b/test/providers/provider_appveyorci.test.ts
@@ -1,7 +1,7 @@
 import td from 'testdouble'
 
 import * as providerAppveyorci from '../../src/ci_providers//provider_appveyorci'
-import { UploaderInputs } from '../../src/types'
+import { IServiceParams, UploaderInputs } from '../../src/types'
 
 describe('AppveyorCI Params', () => {
   afterEach(() => {
@@ -76,14 +76,14 @@ describe('AppveyorCI Params', () => {
         CI: 'true',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'main',
       build: '1',
       buildURL:
         'https%3A%2F%2Fappveyor.com%2Fproject%2FtestOrg%2FtestRepo%2Fbuilds%2F2%2Fjob%2F1',
       commit: 'testingsha',
       job: 'testOrg%2FtestRepo%2F3',
-      pr: '4',
+      pr: 4,
       service: 'appveyor',
       slug: 'testOrg/testRepo',
     }
@@ -106,13 +106,13 @@ describe('AppveyorCI Params', () => {
         CI: 'true',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'branch',
       build: '3',
       buildURL: '',
       commit: 'testsha',
       job: '',
-      pr: '2',
+      pr: 2,
       service: 'appveyor',
       slug: 'testOrg/testRepo',
     }

--- a/test/providers/provider_azurepipelines.test.ts
+++ b/test/providers/provider_azurepipelines.test.ts
@@ -2,7 +2,7 @@ import td from 'testdouble'
 import childProcess from 'child_process'
 
 import * as providerAzurepipelines from '../../src/ci_providers//provider_azurepipelines'
-import { UploaderInputs } from '../../src/types'
+import { IServiceParams, UploaderInputs } from '../../src/types'
 
 describe('Jenkins CI Params', () => {
   afterEach(() => {
@@ -60,14 +60,14 @@ describe('Jenkins CI Params', () => {
         SYSTEM_TEAMPROJECT: 'testOrg',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'main',
       build: '1',
       buildURL:
         'https%3A%2F%2Fexample.azure.comtestOrg%2F_build%2Fresults%3FbuildId%3D2',
       commit: 'testingsha',
       job: '2',
-      pr: '3',
+      pr: 3,
       project: 'testOrg',
       server_uri: 'https://example.azure.com',
       service: 'azure_pipelines',
@@ -96,14 +96,14 @@ describe('Jenkins CI Params', () => {
         SYSTEM_TEAMPROJECT: 'testOrg',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'main',
       build: '1',
       buildURL:
         'https%3A%2F%2Fexample.azure.comtestOrg%2F_build%2Fresults%3FbuildId%3D2',
       commit: 'testingsha',
       job: '2',
-      pr: '3',
+      pr: 3,
       project: 'testOrg',
       server_uri: 'https://example.azure.com',
       service: 'azure_pipelines',
@@ -132,14 +132,14 @@ describe('Jenkins CI Params', () => {
         SYSTEM_TEAMPROJECT: 'testOrg',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'main',
       build: '1',
       buildURL:
         'https%3A%2F%2Fexample.azure.comtestOrg%2F_build%2Fresults%3FbuildId%3D2',
       commit: 'testingmergecommitsha2345678901234567890',
       job: '2',
-      pr: '3',
+      pr: 3,
       project: 'testOrg',
       server_uri: 'https://example.azure.com',
       service: 'azure_pipelines',
@@ -172,13 +172,13 @@ describe('Jenkins CI Params', () => {
         SYSTEM_TEAMFOUNDATIONSERVERURI: 'https://example.azure.com',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'branch',
       build: '3',
       buildURL: '',
       commit: 'testsha',
       job: '',
-      pr: '2',
+      pr: 2,
       project: '',
       server_uri: 'https://example.azure.com',
       service: 'azure_pipelines',

--- a/test/providers/provider_bitbucket.test.ts
+++ b/test/providers/provider_bitbucket.test.ts
@@ -1,7 +1,7 @@
 import childProcess from 'child_process'
 import td from 'testdouble'
 import * as providerBitbucket from '../../src/ci_providers//provider_bitbucket'
-import { UploaderInputs } from '../../src/types'
+import { IServiceParams, UploaderInputs } from '../../src/types'
 
 describe('Bitbucket Params', () => {
   afterEach(() => {
@@ -53,13 +53,13 @@ describe('Bitbucket Params', () => {
         CI: 'true',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: '',
       build: '1',
       buildURL: '',
       commit: '',
       job: '1',
-      pr: '',
+      pr: 0,
       service: 'bitbucket',
       slug: '',
     }
@@ -85,13 +85,13 @@ describe('Bitbucket Params', () => {
         CI: 'true',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'main',
       build: '1',
       buildURL: '',
       commit: 'testingsha',
       job: '1',
-      pr: '2',
+      pr: 2,
       service: 'bitbucket',
       slug: 'testOwner/testSlug',
     }
@@ -116,13 +116,13 @@ describe('Bitbucket Params', () => {
         CI: 'true',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'main',
       build: '1',
       buildURL: '',
       commit: 'testingsha',
       job: '1',
-      pr: '',
+      pr: 0,
       service: 'bitbucket',
       slug: 'testOwner/testSlug',
     }
@@ -147,13 +147,13 @@ describe('Bitbucket Params', () => {
         CI: 'true',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'main',
       build: '1',
       buildURL: '',
       commit: 'newtestsha',
       job: '1',
-      pr: '',
+      pr: 0,
       service: 'bitbucket',
       slug: 'testOwner/testSlug',
     }
@@ -189,13 +189,13 @@ describe('Bitbucket Params', () => {
         CI: 'true',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'feature',
       build: '3',
       buildURL: '',
       commit: 'overwriteSha',
       job: '1',
-      pr: '4',
+      pr: 4,
       service: 'bitbucket',
       slug: 'overwriteOwner/overwriteRepo',
     }

--- a/test/providers/provider_buildkite.test.ts
+++ b/test/providers/provider_buildkite.test.ts
@@ -1,6 +1,6 @@
 import td from 'testdouble'
 import * as providerBuildkite from '../../src/ci_providers/provider_buildkite'
-import { UploaderInputs } from '../../src/types'
+import { IServiceParams, UploaderInputs } from '../../src/types'
 
 describe('Buildkite Params', () => {
   afterEach(() => {
@@ -48,13 +48,13 @@ describe('Buildkite Params', () => {
         CI: 'true',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'main',
       build: '1',
       buildURL: 'https://buildkite.com/testOrg/testRepo',
       commit: 'testingsha',
       job: '3',
-      pr: '',
+      pr: 0,
       service: 'buildkite',
       slug: 'testRepo',
     }
@@ -80,13 +80,13 @@ describe('Buildkite Params', () => {
         CI: 'true',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'branch',
       build: '3',
       buildURL: '',
       commit: 'testsha',
       job: '',
-      pr: '2',
+      pr: 2,
       service: 'buildkite',
       slug: 'testOrg/testRepo',
     }

--- a/test/providers/provider_circleci.test.ts
+++ b/test/providers/provider_circleci.test.ts
@@ -1,6 +1,7 @@
 import td from 'testdouble'
 
 import * as providerCircleci from '../../src/ci_providers//provider_circleci'
+import { IServiceParams } from '../../src/types'
 
 describe('CircleCI Params', () => {
   afterEach(() => {
@@ -48,13 +49,13 @@ describe('CircleCI Params', () => {
         CIRCLE_NODE_INDEX: '3',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'master',
       build: '2',
       buildURL: '',
       commit: 'testingsha',
       job: '3',
-      pr: '1',
+      pr: 1,
       service: 'circleci',
       slug: 'testOrg/testRepo',
     }
@@ -79,13 +80,13 @@ describe('CircleCI Params', () => {
         CIRCLE_NODE_INDEX: '3',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'master',
       build: '2',
       buildURL: '',
       commit: 'testingsha',
       job: '3',
-      pr: '1',
+      pr: 1,
       service: 'circleci',
       slug: 'testOrg/testRepo',
     }

--- a/test/providers/provider_cirrus.test.ts
+++ b/test/providers/provider_cirrus.test.ts
@@ -1,7 +1,7 @@
 import td from 'testdouble'
 
 import * as providerCirrus from '../../src/ci_providers/provider_cirrus'
-import { UploaderInputs } from '../../src/types'
+import { IServiceParams, UploaderInputs } from '../../src/types'
 
 describe('Cirrus Params', () => {
   afterEach(() => {
@@ -49,13 +49,13 @@ describe('Cirrus Params', () => {
         CIRRUS_REPO_FULL_NAME: 'https:/example.com/repo',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'master',
       build: '2',
       buildURL: '',
       commit: 'testingsha',
       job: '',
-      pr: '1',
+      pr: 1,
       service: 'cirrus-ci',
       slug: 'https:/example.com/repo',
     }
@@ -86,13 +86,13 @@ describe('Cirrus Params', () => {
         CIRRUS_REPO_FULL_NAME: 'https:/example.com/repo',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'branch',
       build: '3',
       buildURL: '',
       commit: 'testsha',
       job: '',
-      pr: '2',
+      pr: 2,
       service: 'cirrus-ci',
       slug: 'testOrg/testRepo',
     }

--- a/test/providers/provider_codebuild.test.ts
+++ b/test/providers/provider_codebuild.test.ts
@@ -1,7 +1,7 @@
 import td from 'testdouble'
 
 import * as providerCodeBuild from '../../src/ci_providers/provider_codebuild'
-import { UploaderInputs } from '../../src/types'
+import { IServiceParams, UploaderInputs } from '../../src/types'
 
 describe('CodeBuild Params', () => {
   afterEach(() => {
@@ -55,13 +55,13 @@ describe('CodeBuild Params', () => {
           CODEBUILD_SOURCE_REPO_URL: 'https://github.com/repo.git',
         },
       }
-      const expected = {
+      const expected: IServiceParams = {
         branch: 'master',
         build: '2',
         buildURL: '',
         commit: 'testingsha',
         job: '2',
-        pr: '1',
+        pr: 1,
         service: 'codebuild',
         slug: 'repo',
       }
@@ -92,13 +92,13 @@ describe('CodeBuild Params', () => {
           CODEBUILD_SOURCE_REPO_URL: 'https://github.com/repo.git',
         },
       }
-      const expected = {
+      const expected: IServiceParams = {
         branch: 'branch',
         build: '3',
         buildURL: '',
         commit: 'testsha',
         job: '2',
-        pr: '7',
+        pr: 7,
         service: 'codebuild',
         slug: 'testOrg/testRepo',
       }

--- a/test/providers/provider_drone.test.ts
+++ b/test/providers/provider_drone.test.ts
@@ -1,6 +1,7 @@
 import td from 'testdouble'
 
 import * as providerDrone from '../../src/ci_providers/provider_drone'
+import { IServiceParams } from '../../src/types'
 
 describe('Drone Params', () => {
   afterEach(() => {
@@ -49,13 +50,13 @@ describe('Drone Params', () => {
         DRONE_REPO_LINK: 'https:/example.com/repo',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'master',
       build: '2',
       buildURL: 'https://www.drone.io/',
       commit: 'testingsha',
       job: '',
-      pr: '1',
+      pr: 1,
       service: 'drone',
       slug: 'https:/example.com/repo',
     }

--- a/test/providers/provider_githubactions.test.ts
+++ b/test/providers/provider_githubactions.test.ts
@@ -2,7 +2,7 @@ import td from 'testdouble'
 import childProcess from 'child_process'
 
 import * as providerGitHubactions from '../../src/ci_providers//provider_githubactions'
-import { UploaderInputs } from '../../src/types'
+import { IServiceParams, UploaderInputs } from '../../src/types'
 
 describe('GitHub Actions Params', () => {
   afterEach(() => {
@@ -57,14 +57,14 @@ describe('GitHub Actions Params', () => {
         GITHUB_WORKFLOW: 'testWorkflow',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'master',
       build: '2',
       buildURL:
         'https%3A%2F%2Fgithub.com%2FtestOrg%2FtestRepo%2Factions%2Fruns%2F2',
       commit: 'testingsha',
       job: 'testWorkflow',
-      pr: '',
+      pr: 0,
       service: 'github-actions',
       slug: 'testOrg/testRepo',
     }
@@ -91,14 +91,14 @@ describe('GitHub Actions Params', () => {
         GITHUB_WORKFLOW: 'testWorkflow',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'branch',
       build: '2',
       buildURL:
         'https%3A%2F%2Fgithub.com%2FtestOrg%2FtestRepo%2Factions%2Fruns%2F2',
       commit: 'testingsha',
       job: 'testWorkflow',
-      pr: '1',
+      pr: 1,
       service: 'github-actions',
       slug: 'testOrg/testRepo',
     }
@@ -132,14 +132,14 @@ describe('GitHub Actions Params', () => {
         GITHUB_WORKFLOW: 'testWorkflow',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'branch',
       build: '2',
       buildURL:
         'https%3A%2F%2Fgithub.com%2FtestOrg%2FtestRepo%2Factions%2Fruns%2F2',
       commit: 'testingmergecommitsha2345678901234567890',
       job: 'testWorkflow',
-      pr: '1',
+      pr: 1,
       service: 'github-actions',
       slug: 'testOrg/testRepo',
     }
@@ -173,14 +173,14 @@ describe('GitHub Actions Params', () => {
         GITHUB_SERVER_URL: 'https://github.com',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'branch',
       build: '3',
       buildURL:
         'https%3A%2F%2Fgithub.com%2FtestOrg%2FtestRepo%2Factions%2Fruns%2F3',
       commit: 'testsha',
       job: '',
-      pr: '2',
+      pr: 2,
       service: 'github-actions',
       slug: 'testOrg/testRepo',
     }
@@ -212,14 +212,14 @@ describe('GitHub Actions Params', () => {
         GITHUB_WORKFLOW: 'testWorkflow',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'branch',
       build: '2',
       buildURL:
         'https%3A%2F%2Fgithub.com%2FtestOrg%2FtestRepo%2Factions%2Fruns%2F2',
       commit: 'testingsha',
       job: 'testWorkflow',
-      pr: '1',
+      pr: 1,
       service: 'github-actions',
       slug: 'testOrg/testRepo',
     }

--- a/test/providers/provider_gitlabci.test.ts
+++ b/test/providers/provider_gitlabci.test.ts
@@ -2,7 +2,7 @@ import td from 'testdouble'
 import childProcess from 'child_process'
 
 import * as providerGitLabci from '../../src/ci_providers//provider_gitlabci'
-import { UploaderInputs } from '../../src/types'
+import { IServiceParams, UploaderInputs } from '../../src/types'
 
 describe('GitLabCI Params', () => {
   afterEach(() => {
@@ -45,13 +45,13 @@ describe('GitLabCI Params', () => {
         GITLAB_CI: 'true',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: '',
       build: '',
       buildURL: '',
       commit: '',
       job: '',
-      pr: '',
+      pr: 0,
       service: 'gitlab',
       slug: '',
     }
@@ -82,13 +82,13 @@ describe('GitLabCI Params', () => {
         GITLAB_CI: 'true',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'main',
       build: '1',
       buildURL: '',
       commit: 'testingsha',
       job: '',
-      pr: '',
+      pr: 0,
       service: 'gitlab',
       slug: 'testOrg/testRepo',
     }
@@ -112,13 +112,13 @@ describe('GitLabCI Params', () => {
         GITLAB_CI: 'true',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'master',
       build: '2',
       buildURL: '',
       commit: 'testsha',
       job: '',
-      pr: '',
+      pr: 0,
       service: 'gitlab',
       slug: 'testOrg/testRepo',
     }
@@ -202,13 +202,13 @@ describe('GitLabCI Params', () => {
         GITLAB_CI: 'true',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'branch',
       build: '3',
       buildURL: '',
       commit: 'testsha',
       job: '',
-      pr: '2',
+      pr: 2,
       service: 'gitlab',
       slug: 'testOrg/testRepo',
     }

--- a/test/providers/provider_jenkinsci.test.ts
+++ b/test/providers/provider_jenkinsci.test.ts
@@ -2,7 +2,7 @@ import td from 'testdouble'
 import childProcess from 'child_process'
 
 import * as providerJenkinsci from '../../src/ci_providers//provider_jenkinsci'
-import { UploaderInputs } from '../../src/types'
+import { IServiceParams, UploaderInputs } from '../../src/types'
 
 describe('Jenkins CI Params', () => {
   afterEach(() => {
@@ -57,13 +57,13 @@ describe('Jenkins CI Params', () => {
         JENKINS_URL: 'https://example.com',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'main',
       build: '1',
       buildURL: 'https%3A%2F%2Fexample.jenkins.com',
       commit: 'testingsha',
       job: '',
-      pr: '2',
+      pr: 2,
       service: 'jenkins',
       slug: '',
     }
@@ -118,13 +118,13 @@ describe('Jenkins CI Params', () => {
         JENKINS_URL: 'https://example.com',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'branch',
       build: '3',
       buildURL: '',
       commit: 'testsha',
       job: '',
-      pr: '2',
+      pr: 2,
       service: 'jenkins',
       slug: 'testOrg/testRepo',
     }

--- a/test/providers/provider_local.test.ts
+++ b/test/providers/provider_local.test.ts
@@ -2,7 +2,7 @@ import td from 'testdouble'
 import childProcess from 'child_process'
 
 import * as providerLocal from '../../src/ci_providers//provider_local'
-import { UploaderInputs } from '../../src/types'
+import { IServiceParams, UploaderInputs } from '../../src/types'
 
 describe('Local Params', () => {
   afterEach(() => {
@@ -55,13 +55,13 @@ describe('Local Params', () => {
       },
       envs: {},
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'main',
       build: '',
       buildURL: '',
       commit: 'testingsha',
       job: '',
-      pr: '1',
+      pr: 1,
       service: '',
       slug: 'owner/repo',
     }

--- a/test/providers/provider_teamcity.test.ts
+++ b/test/providers/provider_teamcity.test.ts
@@ -2,6 +2,7 @@ import td from 'testdouble'
 import childProcess from 'child_process'
 
 import * as providerTeamCity from '../../src/ci_providers/provider_teamcity'
+import { IServiceParams } from '../../src/types'
 
 describe('TeamCity Params', () => {
   afterEach(() => {
@@ -51,13 +52,13 @@ describe('TeamCity Params', () => {
         BUILD_NUMBER: '1',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'main',
       build: '1',
       buildURL: '',
       commit: 'testingsha',
       job: '',
-      pr: '',
+      pr: 0,
       service: 'teamcity',
       slug: '',
     }
@@ -85,13 +86,13 @@ describe('TeamCity Params', () => {
         BUILD_NUMBER: '1',
       },
     }
-    const expected = {
+    const expected : IServiceParams= {
       branch: 'main',
       build: '1',
       buildURL: '',
       commit: 'testingsha',
       job: '',
-      pr: '',
+      pr: 0,
       service: 'teamcity',
       slug: 'testOrg/testRepo',
     }
@@ -128,13 +129,13 @@ describe('TeamCity Params', () => {
     td.when(
       spawnSync('git', ['config', '--get', 'remote.origin.url']),
     ).thenReturn({ stdout: '' })
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'branch',
       build: '3',
       buildURL: '',
       commit: 'testsha',
       job: '',
-      pr: '2',
+      pr: 2,
       service: 'teamcity',
       slug: 'testOrg/testRepo',
     }

--- a/test/providers/provider_template.test.ts
+++ b/test/providers/provider_template.test.ts
@@ -1,6 +1,6 @@
 import td from 'testdouble'
 import childProcess from 'child_process'
-import { UploaderInputs } from '../../src/types'
+import { IServiceParams, UploaderInputs } from '../../src/types'
 
 /*
 Add your provider here and name it provder<Ci>. Example:
@@ -42,13 +42,13 @@ describe('<Ci> Params', () => {
       args: { tag: '', url: '', source: '', flags: '' },
       envs: {},
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: '',
       build: '',
       buildURL: '',
       commit: '',
       job: '',
-      pr: '',
+      pr: 0,
       service: '',
       slug: '',
     }
@@ -64,13 +64,13 @@ describe('<Ci> Params', () => {
       args: { tag: '', url: '', source: '', flags: '' },
       envs: {},
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: '',
       build: '',
       buildURL: '',
       commit: '',
       job: '',
-      pr: '',
+      pr: 0,
       service: '',
       slug: '',
     }
@@ -91,13 +91,13 @@ describe('<Ci> Params', () => {
       },
       envs: {},
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: '',
       build: '',
       buildURL: '',
       commit: '',
       job: '',
-      pr: '',
+      pr: 0,
       service: '',
       slug: '',
     }
@@ -118,13 +118,13 @@ describe('<Ci> Params', () => {
       },
       envs: {},
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: '',
       build: '',
       buildURL: '',
       commit: '',
       job: '',
-      pr: '',
+      pr: 0,
       service: '',
       slug: '',
     }

--- a/test/providers/provider_travisci.test.ts
+++ b/test/providers/provider_travisci.test.ts
@@ -1,7 +1,7 @@
 import td from 'testdouble'
 
 import * as providerTravisci from '../../src/ci_providers/provider_travisci'
-import { UploaderInputs } from '../../src/types'
+import { IServiceParams, UploaderInputs } from '../../src/types'
 
 describe('TravisCI Params', () => {
   afterEach(() => {
@@ -66,13 +66,13 @@ describe('TravisCI Params', () => {
         TRAVIS_REPO_SLUG: 'testOrg/testRepo',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: '',
       build: '1',
       buildURL: '',
       commit: 'testingsha',
       job: '2',
-      pr: '',
+      pr: 0,
       service: 'travis',
       slug: 'testOrg/testRepo',
     }
@@ -103,13 +103,13 @@ describe('TravisCI Params', () => {
         TRAVIS_TAG: 'main',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'branch',
       build: '1',
       buildURL: '',
       commit: 'testingprsha',
       job: '2',
-      pr: '',
+      pr: 0,
       service: 'travis',
       slug: 'testOrg/testRepo',
     }
@@ -139,13 +139,13 @@ describe('TravisCI Params', () => {
         TRAVIS_TAG: 'main',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'branch',
       build: '1',
       buildURL: '',
       commit: 'testingprsha',
       job: '2',
-      pr: '',
+      pr: 0,
       service: 'travis',
       slug: 'testOrg/testRepo',
     }
@@ -172,13 +172,13 @@ describe('TravisCI Params', () => {
         TRAVIS: 'true',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'branch',
       build: '3',
       buildURL: '',
       commit: 'testsha',
       job: '',
-      pr: '2',
+      pr: 2,
       service: 'travis',
       slug: 'testOrg/testRepo',
     }

--- a/test/providers/provider_wercker.test.ts
+++ b/test/providers/provider_wercker.test.ts
@@ -1,7 +1,7 @@
 import td from 'testdouble'
 
 import * as providerWercker from '../../src/ci_providers/provider_wercker'
-import { UploaderArgs, UploaderInputs } from '../../src/types'
+import { IServiceParams, UploaderArgs, UploaderInputs } from '../../src/types'
 
 describe('Wercker CI Params', () => {
   afterEach(() => {
@@ -53,13 +53,13 @@ describe('Wercker CI Params', () => {
         WERCKER_BUILD_URL: 'https://example.com/build',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'main',
       build: '1',
       buildURL: 'https://example.com/build',
       commit: 'testingsha',
       job: '',
-      pr: '',
+      pr: 0,
       service: 'wercker',
       slug: 'testOrg/testRepo',
     }
@@ -90,13 +90,13 @@ describe('Wercker CI Params', () => {
         WERCKER_BUILD_URL: 'https://example.com/build',
       },
     }
-    const expected = {
+    const expected: IServiceParams = {
       branch: 'branch',
       build: '3',
       buildURL: 'https://example.com/build',
       commit: 'testsha',
       job: '',
-      pr: '2',
+      pr: 2,
       service: 'wercker',
       slug: 'testOrg/testRepo',
     }


### PR DESCRIPTION
Server validation requires that the `pr` value be a valid number.
This change requires the value of `pr` to be either a number or empty prior to uploading.

Discovered by @dbhobbs
