### PR TITLE
fix: Remove __pycache__ and .tox folders from search

### DIFF
--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -34,8 +34,6 @@ export function manualBlacklist(): string[] {
     '.gitignore',
     '.nvmrc',
     '.nyc_output',
-    '.tox',
-    '__pycache__',
     'node_modules',
     'vendor',
   ]
@@ -260,7 +258,7 @@ export function getAllFiles(
   arrayOfFiles: string[] = [],
 ): string[] {
   verbose(`Searching for files in ${dirPath}`, Boolean(args.verbose))
-  
+
   return glob.sync(['**/*', '**/.[!.]*'], {
     cwd: projectRoot,
     ignore: globBlacklist(),

--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -28,13 +28,15 @@ export async function getFileListing(
 export function manualBlacklist(): string[] {
   // TODO: honor the .gitignore file instead of a hard-coded list
   return [
-    'node_modules',
-    '.git',
-    '.nyc_output',
-    '.circleci',
-    '.nvmrc',
-    '.gitignore',
     '.DS_Store',
+    '.circleci',
+    '.git',
+    '.gitignore',
+    '.nvmrc',
+    '.nyc_output',
+    '.tox',
+    '__pycache__',
+    'node_modules',
     'vendor',
   ]
 }
@@ -42,13 +44,15 @@ export function manualBlacklist(): string[] {
 export function globBlacklist(): string[] {
   // TODO: honor the .gitignore file instead of a hard-coded list
   return [
+    '__pycache__',
     'node_modules/**/*',
     'vendor',
-    '.git',
-    '.nyc_output',
     '.circleci',
-    '.nvmrc',
+    '.git',
     '.gitignore',
+    '.nvmrc',
+    '.nyc_output',
+    '.tox',
     '*.am',
     '*.bash',
     '*.bat',


### PR DESCRIPTION
I'll be honest, not totally sure how we are doing `manualBlacklist` and `globBlacklist` anymore. 

fixes https://github.com/codecov/uploader/issues/259