### PR TITLE
Add new Apex file format to upload ignore list

### DIFF
--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -139,6 +139,7 @@ export function globBlacklist(): string[] {
     'phpunit-coverage.xml',
     'remapInstanbul.coverage*.json',
     'scoverage.measurements.*',
+    'test-result-*-codecoverage.json',
     'test_*_coverage.txt',
     'testrunner-coverage*',
   ]


### PR DESCRIPTION
Salesforce has added new json files `test-result-<testrunid>-codecoverage.json` that contain class/method coverage info on a per test basis. We only need the existing `test-result-codecoverage.json` file to calculate per line coverage, so we can safely ignore the other ones.