### PR TITLE
Add "dist/*" to `exclude`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "resolveJsonModule": true,
     "skipLibCheck": true
   },
-  "exclude": ["test/*"]
+  "exclude": ["dist/*", "test/*"]
 }


### PR DESCRIPTION
TypeScript is unable to perform back-to-back compilations due to the input directory being intertwined with the would-be output directory:

```console
$ tsc  --build
error TS5055: Cannot write file '/[…]/uploader/dist/bin/codecov.d.ts' because it would overwrite input file.
[…]
```