### PR TITLE
Don't upload coverage reports more than once

### DIFF
--- a/src/helpers/web.ts
+++ b/src/helpers/web.ts
@@ -91,9 +91,6 @@ export async function uploadToCodecov(
       )}&token=${token}&${query}`,
     )
     .retry()
-    .send(uploadFile)
-    .set('Content-Type', 'text/plain')
-    .set('Content-Encoding', 'gzip')
     .set('X-Upload-Token', token)
     .set('X-Reduced-Redundancy', 'false')
     .on('error', err => {


### PR DESCRIPTION
Coverage reports are currently sent twice:
- [`uploadToCodecov`](https://github.com/codecov/uploader/blob/037e1e74331080fdad25e550d8fdb7785c17b330/src/helpers/web.ts#L94)
- [`uploadToCodecovPUT`](https://github.com/codecov/uploader/blob/037e1e74331080fdad25e550d8fdb7785c17b330/src/helpers/web.ts#L59)