### PR TITLE
Remove filename validation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -149,8 +149,7 @@ export async function main(
 
   // Remove invalid and duplicate file paths
   coverageFilePaths = [... new Set(coverageFilePaths.filter(file => {
-    return validateHelpers.validateFileNamePath(file) &&
-      fileExists(args.dir || projectRoot, file)
+    return fileExists(args.dir || projectRoot, file)
   }))]
 
   if (coverageFilePaths.length > 0) {


### PR DESCRIPTION
The current filename validation is too strict; furthermore, it is not currently necessary since the underlying file system is capable of raising an error if it receives an invalid file name.

Fixes #303