### PR TITLE
fix: Parse multiple flags properly

### DIFF
--- a/bin/codecov.ts
+++ b/bin/codecov.ts
@@ -7,7 +7,7 @@ var argv = require('yargs') // eslint-disable-line
 
 
 argv.usage('Usage: $0 <command> [options]')
-  
+
 addArguments(argv)
 
   argv.version()

--- a/src/helpers/web.ts
+++ b/src/helpers/web.ts
@@ -21,15 +21,17 @@ export function populateBuildParams(
   const { args, environment: envs } = inputs
   serviceParams.name = args.name || envs.CODECOV_NAME || ''
   serviceParams.tag = args.tag || ''
+
   let flags: string[]
   if (typeof args.flags === 'object') {
     flags = [...args.flags]
   } else {
-    flags = [args.flags || '']
+    flags = (args.flags || '').split(',')
   }
   serviceParams.flags = flags
     .filter(flag => validateHelpers.validateFlags(flag))
     .join(',')
+
   serviceParams.parent = args.parent || ''
   return serviceParams
 }

--- a/test/helpers/web.test.ts
+++ b/test/helpers/web.test.ts
@@ -97,7 +97,8 @@ describe('Web Helpers', () => {
       { args: { flags: 'testFlag', tag: 'testTag' }, environment: {} },
       {
         name: '',
-        tag: ', flags: []',
+        tag: ',',
+        flags: '',
         branch: '',
         build: '',
         buildURL: '',
@@ -111,12 +112,33 @@ describe('Web Helpers', () => {
     expect(result.flags).toBe('testFlag')
   })
 
-  it('can populateBuildParams() from args with multiple flags', () => {
+  it('can populateBuildParams() from args with multiple flags as string', () => {
+    const result = webHelper.populateBuildParams(
+      { args: { flags: 'testFlag1,testFlag2', tag: 'testTag' }, environment: {} },
+      {
+        name: '',
+        tag: '',
+        flags: '',
+        branch: '',
+        build: '',
+        buildURL: '',
+        commit: '',
+        job: '',
+        service: 'Testing',
+        slug: '',
+        pr: 0,
+      },
+    )
+    expect(result.flags).toBe('testFlag1,testFlag2')
+  })
+
+  it('can populateBuildParams() from args with multiple flags as list', () => {
     const result = webHelper.populateBuildParams(
       { args: { flags: ['testFlag1', 'testFlag2'], tag: 'testTag' }, environment: {} },
       {
         name: '',
-        tag: ', flags: []',
+        tag: '',
+        flags: '',
         branch: '',
         build: '',
         buildURL: '',


### PR DESCRIPTION
Flags are now getting passed in as a `string`, not a `string[]`, so the prior validation would throw out the entire string.