### PR TITLE
chore: batch dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,11 @@
     {
       "matchPackageNames": ["pkg"],
       "allowedVersions": "4.4.8"
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "devDependencies (non-major)"
     }
-  ]
+    ]
 }


### PR DESCRIPTION
This will cause Renovate to batch all non-major dependency updates into a single PR