### PR TITLE
fix: 🐛 Preserve LF in the report file names list

### DIFF
--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -262,16 +262,14 @@ export function getAllFiles(
     error,
   } = spawnSync('git', ['-C', dirPath, 'ls-files'], { encoding: 'utf8' })
 
-  if (error instanceof Error || status !== 0) {
-    return glob
+  let fileList: string[] = error instanceof Error || status !== 0
+    ? glob
       .sync(['**/*', '**/.[!.]*'], {
         cwd: dirPath,
         ignore: manualBlacklist().map(globstar),
       })
-      .map(file => `${file}\n`)
-  } else {
-    return stdout.split(/[\r\n]+/)
-  }
+    : stdout.split(/[\r\n]+/)
+  return fileList.map(file => `${file}\n`);
 }
 
 /**

--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -6,7 +6,7 @@ import { posix as path } from 'path'
 import { UploaderArgs } from '../types'
 import { logError, verbose } from './logger'
 
-export const MARKER_NETWORK_END = '<<<<<< network\n'
+export const MARKER_NETWORK_END = '\n<<<<<< network\n'
 export const MARKER_FILE_END = '<<<<<< EOF\n'
 export const MARKER_ENV_END = '<<<<<< ENV\n'
 
@@ -22,7 +22,7 @@ export async function getFileListing(
   projectRoot: string,
   args: UploaderArgs,
 ): Promise<string> {
-  return getAllFiles(projectRoot, projectRoot, args).join('')
+  return getAllFiles(projectRoot, projectRoot, args).join('\n')
 }
 
 export function manualBlacklist(): string[] {
@@ -262,14 +262,13 @@ export function getAllFiles(
     error,
   } = spawnSync('git', ['-C', dirPath, 'ls-files'], { encoding: 'utf8' })
 
-  let fileList: string[] = error instanceof Error || status !== 0
+  return error instanceof Error || status !== 0
     ? glob
       .sync(['**/*', '**/.[!.]*'], {
         cwd: dirPath,
         ignore: manualBlacklist().map(globstar),
       })
     : stdout.split(/[\r\n]+/)
-  return fileList.map(file => `${file}\n`);
 }
 
 /**

--- a/test/helpers/files.test.ts
+++ b/test/helpers/files.test.ts
@@ -11,7 +11,7 @@ describe('File Helpers', () => {
   })
 
   it('provides network end marker', () => {
-    expect(fileHelpers.MARKER_NETWORK_END).toBe('<<<<<< network\n')
+    expect(fileHelpers.MARKER_NETWORK_END).toBe('\n<<<<<< network\n')
   })
 
   it('provides file end marker', () => {


### PR DESCRIPTION
Fixes #411