### PR TITLE
fix: prefer `token` over `slug`

### DIFF
--- a/src/helpers/provider.ts
+++ b/src/helpers/provider.ts
@@ -2,19 +2,19 @@ import providers from '../ci_providers'
 import { info, logError, verbose } from '../helpers/logger'
 import { IServiceParams, UploaderInputs } from '../types'
 
-export function detectProvider(inputs: UploaderInputs): Partial<IServiceParams> {
+export function detectProvider(inputs: UploaderInputs, hasToken = false): Partial<IServiceParams> {
   const { args, environment } = inputs
   let serviceParams: Partial<IServiceParams> | undefined
 
   //   check if we have a complete set of manual overrides (slug, SHA)
-  if (args.sha && args.slug) {
+  if (args.sha && (args.slug || hasToken)) {
     // We have the needed args for a manual override
     info(
       `Using manual override from args.`,
     )
     serviceParams = {
       commit: args.sha,
-      slug: args.slug,
+      ...(hasToken ? {} : { slug: args.slug }),
     }
   } else {
     serviceParams = undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,7 +229,9 @@ export async function main(
 
   // == Step 7: determine CI provider
 
-const serviceParams = detectProvider(inputs)
+  const hasToken = token !== ''
+
+const serviceParams = detectProvider(inputs, hasToken)
 
   // == Step 8: either upload or dry-run
 

--- a/test/helpers/provider.test.ts
+++ b/test/helpers/provider.test.ts
@@ -23,6 +23,19 @@ describe('detectProvider()', () => {
     }
     expect(detectProvider(inputs)).toMatchObject(expectedOutput)
   })
+  
+  it('can detect a manual override with token', () => {
+    const inputs: UploaderInputs = {
+      args: {
+        sha: '1234566',
+      },
+      environment: {},
+    }
+    const expectedOutput: Partial<IServiceParams> = {
+      commit: '1234566',
+    }
+    expect(detectProvider(inputs, true)).toMatchObject(expectedOutput)
+  })
 
   it('will throw if unable to detect', () => {
     jest.spyOn(console, 'error').mockImplementation(() => void {})


### PR DESCRIPTION
Fixes #261