### PR TITLE
Collect Code Climate files

### DIFF
--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -171,6 +171,7 @@ export function coverageFilePatterns(): string[] {
     'gcov.info',
     '*.gcov',
     '*.lst',
+    'codeclimate?(*).json',
   ]
 }
 


### PR DESCRIPTION
The additional glob entry matches "codeclimate.json" in addition to variations such as:
- codeclimate.api.json
- codeclimate.api.production.json