### PR TITLE
ci: test codeco circleci orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 
 orbs:
   win: circleci/windows@2.4.1
-  codecov: codecov/codecov@3.20
+  codecov: codecov/codecov@3.2.0
 
 jobs:
   build-linux-and-osx:


### PR DESCRIPTION
Troubleshooting the following error reported by a customer using the Orb
```
#!/bin/bash -eo pipefail
source $BASH_ENV
chmod +x $filename
[ -n "" ] && set - "${@}" "-f" ""
[ -n "-c -v" ] && set - "${@}" "-c -v"
./$filename \
 -Q "codecov-circleci-orb-3.1.0" \
 -t "${CODECOV_TOKEN}" \
 -n "${CIRCLE_BUILD_NUM}" \
 -F "unit_tests" \
 ${@}


Exited with code exit status 4
CircleCI received exit code 4
```
No other output.