### PR TITLE
Persist Binary to Workspace and Add it to Standards Comparison Script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,6 +462,9 @@ jobs:
     machine: true
     steps:
       - checkout
+      - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+          at: .
       - run:
           name: Clone Autotest and Start Acceptance Testing Containers
           command: |
@@ -484,6 +487,8 @@ workflows:
           context:
             - 'DockerHub Push Context'
             - 'Github Checkout'
+          requires:
+            - build-alpine
       - build-linux-and-osx
       - build-alpine:
           requires:

--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,4 @@ build_alpine:
 .PHONY: run-standards-comparison
 run-standards-comparison:
 	docker pull codecov/autotest:standards-latest > /dev/null 2>&1
-	docker run --network autotest_codecov -e HOST_URL=http://web.local:5000 codecov/autotest:standards-latest
+	docker run --network autotest_codecov -e HOST_URL=http://web.local:5000 -e IS_UPLOADER=true -it -v "$(PWD)/out:/usr/app/out" codecov/autotest:standards-latest


### PR DESCRIPTION
## Description
This PR is to persist the codecov-alpine binary so it can be mounted to the comparison script during runtime. 