### PR TITLE
Fix false positive detection for Heroku-provider

### DIFF
--- a/src/ci_providers/provider_herokuci.ts
+++ b/src/ci_providers/provider_herokuci.ts
@@ -2,7 +2,7 @@ import { parseSlugFromRemoteAddr } from '../helpers/git'
 import { IServiceParams, UploaderEnvs, UploaderInputs } from '../types'
 
 export function detect(envs: UploaderEnvs): boolean {
-  return Boolean(envs.CI) && envs.HEROKU_TEST_RUN_BRANCH != ''
+  return Boolean(envs.CI) && Boolean(envs.HEROKU_TEST_RUN_BRANCH)
 }
 
 function _getBuild(inputs: UploaderInputs): string {


### PR DESCRIPTION
This PR fixes an error where Jenkins is incorrectly detected as Heroku, thus breaking the upload of coverage data since the provider cannot find the proper SHA for the report.

The problem is that the environment variable `HEROKU_TEST_RUN_BRANCH` is `undefined` which when losely compared to empty string will become `true` whereas what we really want to know is if it actually has any value. Looked through the other providers and you seem to like checking this by casting it as a boolean so I decided to do the same

![image](https://user-images.githubusercontent.com/19795086/139878439-97c7bd0b-44e2-48a4-b7b0-3336994703b9.png)
