### PR TITLE
refactor: slug detection handling cleanup

### DIFF
--- a/src/ci_providers/provider_appveyorci.ts
+++ b/src/ci_providers/provider_appveyorci.ts
@@ -63,7 +63,8 @@ function _getSHA(inputs: UploaderInputs) {
 
 function _getSlug(inputs: UploaderInputs) {
   const { args, environment: envs } = inputs
-  return args.slug || envs.APPVEYOR_REPO_NAME || ''
+  if (args.slug !== '') return args.slug
+  return envs.APPVEYOR_REPO_NAME || ''
 }
 
 export function getServiceParams(inputs: UploaderInputs): IServiceParams {

--- a/src/ci_providers/provider_azurepipelines.ts
+++ b/src/ci_providers/provider_azurepipelines.ts
@@ -85,7 +85,8 @@ function _getServerURI(inputs: UploaderInputs): string {
 
 function _getSlug(inputs: UploaderInputs): string {
   const { args, environment: envs } = inputs
-  return args.slug || envs.BUILD_REPOSITORY_NAME || parseSlugFromRemoteAddr('') || ''
+  if (args.slug !== '') return args.slug
+  return envs.BUILD_REPOSITORY_NAME || parseSlugFromRemoteAddr('') || ''
 }
 /**
  * Generates and return the serviceParams object

--- a/src/ci_providers/provider_bitbucket.ts
+++ b/src/ci_providers/provider_bitbucket.ts
@@ -51,8 +51,8 @@ function _getSHA(inputs: UploaderInputs): string {
 
 function _getSlug(inputs: UploaderInputs): string {
   const { args, environment: envs } = inputs
-
-  return args.slug || envs.BITBUCKET_REPO_FULL_NAME || ''
+  if (args.slug !== '') return args.slug
+  return envs.BITBUCKET_REPO_FULL_NAME || ''
 }
 
 export function getServiceParams(inputs: UploaderInputs): IServiceParams {

--- a/src/ci_providers/provider_buildkite.ts
+++ b/src/ci_providers/provider_buildkite.ts
@@ -1,3 +1,4 @@
+import { setSlug } from '../helpers/provider'
 import { IServiceParams, UploaderEnvs, UploaderInputs } from '../types'
 
 /**
@@ -101,10 +102,7 @@ function _getSHA(inputs: UploaderInputs): string {
  */
 function _getSlug(inputs: UploaderInputs): string {
   const { args, environment: envs } = inputs
-  if (args.slug || envs.BUILDKITE_PIPELINE_SLUG) {
-    return args.slug || envs.BUILDKITE_PIPELINE_SLUG || ''
-  }
-  throw new Error('Unable to detect slug, please set manually with the -r flag')
+  return setSlug(args.slug, envs.BUILDKITE_ORGANIZATION_SLUG, envs.BUILDKITE_PIPELINE_SLUG)
 }
 /**
  * Generates and return the serviceParams object

--- a/src/ci_providers/provider_circleci.ts
+++ b/src/ci_providers/provider_circleci.ts
@@ -1,3 +1,5 @@
+import { setSlug } from '../helpers/provider'
+import { isSetAndNotEmpty } from '../helpers/util'
 import { IServiceParams, UploaderEnvs, UploaderInputs } from '../types'
 
 export function detect(envs: UploaderEnvs): boolean {
@@ -30,19 +32,20 @@ function _getSHA(inputs: UploaderInputs): string {
 
 function _getSlug(inputs: UploaderInputs): string {
   const { args, environment: envs } = inputs
-  if (args.slug !== '') {
-    return args.slug
+
+  const slug = setSlug(
+    args.slug,
+    envs.CIRCLE_PROJECT_USERNAME,
+    envs.CIRCLE_PROJECT_REPONAME,
+  )
+  if (slug !== '') {
+    return slug
   }
-  if (
-    typeof envs.CIRCLE_PROJECT_USERNAME !== 'undefined' &&
-    typeof envs.CIRCLE_PROJECT_REPONAME !== 'undefined'
-  ) {
-    return `${envs.CIRCLE_PROJECT_USERNAME}/${envs.CIRCLE_PROJECT_REPONAME}`
+
+  if (isSetAndNotEmpty(envs.CIRCLE_REPOSITORY_URL)) {
+    return `${envs.CIRCLE_REPOSITORY_URL?.split(':')[1].split('.git')[0]}`
   }
-  if (typeof envs.CIRCLE_REPOSITORY_URL !== "undefined") {
-    return `${envs.CIRCLE_REPOSITORY_URL.split(':')[1].split('.git')[0]}`
-  }
-  return ''
+  return slug
 }
 
 function _getBuild(inputs: UploaderInputs): string {

--- a/src/ci_providers/provider_circleci.ts
+++ b/src/ci_providers/provider_circleci.ts
@@ -30,22 +30,19 @@ function _getSHA(inputs: UploaderInputs): string {
 
 function _getSlug(inputs: UploaderInputs): string {
   const { args, environment: envs } = inputs
-  let slug = args.slug || ''
-  if (slug !== '') {
-    return slug
+  if (args.slug !== '') {
+    return args.slug
   }
-  if (envs.CIRCLE_PROJECT_REPONAME !== '') {
-    slug = `${envs.CIRCLE_PROJECT_USERNAME}/${envs.CIRCLE_PROJECT_REPONAME}`
-  } else {
-    if (envs.CIRCLE_REPOSITORY_URL) {
-      slug = `${envs.CIRCLE_REPOSITORY_URL.split(':')[1].split('.git')[0]}`
-    } else {
-      throw new Error(
-        'Unable to detect slug from env. Please set manually with the -r flag',
-      )
-    }
+  if (
+    typeof envs.CIRCLE_PROJECT_USERNAME !== 'undefined' &&
+    typeof envs.CIRCLE_PROJECT_REPONAME !== 'undefined'
+  ) {
+    return `${envs.CIRCLE_PROJECT_USERNAME}/${envs.CIRCLE_PROJECT_REPONAME}`
   }
-  return args.slug || slug
+  if (typeof envs.CIRCLE_REPOSITORY_URL !== "undefined") {
+    return `${envs.CIRCLE_REPOSITORY_URL.split(':')[1].split('.git')[0]}`
+  }
+  return ''
 }
 
 function _getBuild(inputs: UploaderInputs): string {

--- a/src/ci_providers/provider_cirrus.ts
+++ b/src/ci_providers/provider_cirrus.ts
@@ -1,3 +1,7 @@
+/**
+ * https://cirrus-ci.org/guide/writing-tasks/#environment-variables
+ */
+import { setSlug } from '../helpers/provider'
 import { IServiceParams, UploaderEnvs, UploaderInputs } from '../types'
 
 export function detect(envs: UploaderEnvs): boolean {
@@ -42,7 +46,7 @@ function _getSHA(inputs: UploaderInputs): string {
 
 function _getSlug(inputs: UploaderInputs): string {
   const { args, environment: envs } = inputs
-  return args.slug || envs.CIRRUS_REPO_FULL_NAME || ''
+  return setSlug(args.slug, envs.CIRRUS_REPO_OWNER, envs.CIRRUS_REPO_NAME)
 }
 
 export function getServiceParams(inputs: UploaderInputs): IServiceParams {

--- a/src/ci_providers/provider_codebuild.ts
+++ b/src/ci_providers/provider_codebuild.ts
@@ -53,8 +53,8 @@ function _getSHA(inputs: UploaderInputs): string {
 
 function _getSlug(inputs: UploaderInputs): string {
   const { args, environment: envs } = inputs
+  if (args.slug !== '') return args.slug
   return (
-    args.slug ||
     (envs.CODEBUILD_SOURCE_REPO_URL
       ? envs.CODEBUILD_SOURCE_REPO_URL.toString()
           .replace(/^.*github.com\//, '') // lgtm [js/incomplete-hostname-regexp] - We want this to match all subdomains.

--- a/src/ci_providers/provider_drone.ts
+++ b/src/ci_providers/provider_drone.ts
@@ -1,3 +1,6 @@
+/**
+ * https://docs.drone.io/runner/exec/configuration/reference/
+ */
 import { IServiceParams, UploaderEnvs, UploaderInputs } from '../types'
 
 export function detect(envs: UploaderEnvs): boolean {
@@ -43,7 +46,8 @@ function _getSHA(inputs: UploaderInputs): string {
 
 function _getSlug(inputs: UploaderInputs): string {
   const { args, environment: envs } = inputs
-  return args.slug || envs.DRONE_REPO || ''
+  if (args.slug !== '') return args.slug
+  return envs.DRONE_REPO || ''
 }
 
 export function getServiceParams(inputs: UploaderInputs): IServiceParams {

--- a/src/ci_providers/provider_githubactions.ts
+++ b/src/ci_providers/provider_githubactions.ts
@@ -1,3 +1,6 @@
+/**
+ * https://docs.github.com/en/actions/learn-github-actions/environment-variables
+ */
 import { IServiceParams, UploaderEnvs, UploaderInputs } from '../types'
 
 import childProcess from 'child_process'
@@ -88,7 +91,8 @@ function _getSHA(inputs: UploaderInputs): string {
 
 function _getSlug(inputs: UploaderInputs): string {
   const { args, environment: envs } = inputs
-  return args.slug || envs.GITHUB_REPOSITORY || ''
+  if (args.slug !== '') return args.slug
+  return envs.GITHUB_REPOSITORY || ''
 }
 
 export function getServiceParams(inputs: UploaderInputs): IServiceParams {

--- a/src/ci_providers/provider_gitlabci.ts
+++ b/src/ci_providers/provider_gitlabci.ts
@@ -44,9 +44,9 @@ function _getSHA(inputs: UploaderInputs): string {
 
 function _getSlug(inputs: UploaderInputs): string {
   const { args, environment: envs } = inputs
+  if (args.slug !== '') return args.slug
   const remoteAddr = envs.CI_BUILD_REPO || envs.CI_REPOSITORY_URL || ''
   return (
-    args.slug ||
     envs.CI_PROJECT_PATH ||
     parseSlugFromRemoteAddr(remoteAddr) ||
     ''

--- a/src/ci_providers/provider_herokuci.ts
+++ b/src/ci_providers/provider_herokuci.ts
@@ -43,7 +43,8 @@ function _getSHA(inputs: UploaderInputs): string {
 
 function _getSlug(inputs: UploaderInputs): string {
   const { args } = inputs
-  return args.slug || parseSlugFromRemoteAddr('') || ''
+  if (args.slug !== '') return args.slug
+  return parseSlugFromRemoteAddr('') || ''
 }
 
 export function getServiceParams(inputs: UploaderInputs): IServiceParams {

--- a/src/ci_providers/provider_jenkinsci.ts
+++ b/src/ci_providers/provider_jenkinsci.ts
@@ -50,7 +50,8 @@ function _getSHA(inputs: UploaderInputs): string {
 
 function _getSlug(inputs: UploaderInputs): string {
   const { args } = inputs
-  return args.slug || parseSlugFromRemoteAddr('') || ''
+  if (args.slug !== '') return args.slug
+  return parseSlugFromRemoteAddr('') || ''
 }
 
 export function getServiceParams(inputs: UploaderInputs): IServiceParams {

--- a/src/ci_providers/provider_teamcity.ts
+++ b/src/ci_providers/provider_teamcity.ts
@@ -31,7 +31,8 @@ function _getSHA(inputs: UploaderInputs): string {
 
 function _getSlug(inputs: UploaderInputs): string {
   const { args } = inputs
-  return args.slug || parseSlugFromRemoteAddr('') || ''
+  if (args.slug !== '') return args.slug
+  return parseSlugFromRemoteAddr('') || ''
 }
 
 function _getBuild(inputs: UploaderInputs): string {

--- a/src/ci_providers/provider_travisci.ts
+++ b/src/ci_providers/provider_travisci.ts
@@ -47,7 +47,8 @@ function _getSHA(inputs: UploaderInputs): string {
 
 function _getSlug(inputs: UploaderInputs): string {
   const { args, environment: envs } = inputs
-  return args.slug || envs.TRAVIS_REPO_SLUG || ''
+  if (args.slug !== '') return args.slug
+  return envs.TRAVIS_REPO_SLUG || ''
 }
 
 export function getServiceParams(inputs: UploaderInputs): IServiceParams {

--- a/src/ci_providers/provider_wercker.ts
+++ b/src/ci_providers/provider_wercker.ts
@@ -1,3 +1,4 @@
+import { setSlug } from '../helpers/provider'
 import { IServiceParams, UploaderEnvs, UploaderInputs } from '../types'
 
 export function detect(envs: UploaderEnvs): boolean {
@@ -44,7 +45,7 @@ function _getSHA(inputs: UploaderInputs): string {
 
 function _getSlug(inputs: UploaderInputs): string {
   const { args, environment: envs } = inputs
-  return args.slug || `${envs.WERCKER_GIT_OWNER}/${envs.WERCKER_GIT_REPOSITORY}`
+  return setSlug(args.slug, envs.WERCKER_GIT_OWNER, envs.WERCKER_GIT_REPOSITORY)
 }
 
 export function getServiceParams(inputs: UploaderInputs): IServiceParams {

--- a/src/helpers/cli.ts
+++ b/src/helpers/cli.ts
@@ -106,6 +106,7 @@ const args: ICLIArgument[] = [
   {
     alias: 'r',
     name: 'slug',
+    default: '',
     description: 'Specify the slug manually',
   },
   {

--- a/src/helpers/provider.ts
+++ b/src/helpers/provider.ts
@@ -2,16 +2,17 @@ import providers from '../ci_providers'
 import { info, logError, verbose } from '../helpers/logger'
 import { IServiceParams, UploaderInputs } from '../types'
 
-export function detectProvider(inputs: UploaderInputs, hasToken = false): Partial<IServiceParams> {
+export function detectProvider(
+  inputs: UploaderInputs,
+  hasToken = false,
+): Partial<IServiceParams> {
   const { args } = inputs
   let serviceParams: Partial<IServiceParams> | undefined
 
   //   check if we have a complete set of manual overrides (slug, SHA)
   if (args.sha && (args.slug || hasToken)) {
     // We have the needed args for a manual override
-    info(
-      `Using manual override from args.`,
-    )
+    info(`Using manual override from args.`)
     serviceParams = {
       commit: args.sha,
       ...(hasToken ? {} : { slug: args.slug }),
@@ -25,7 +26,7 @@ export function detectProvider(inputs: UploaderInputs, hasToken = false): Partia
     return { ...walkProviders(inputs), ...serviceParams }
   } catch (error) {
     //   if fails, display message explaining failure, and explaining that SHA and slug need to be set as args
-    if (typeof serviceParams !== "undefined") {
+    if (typeof serviceParams !== 'undefined') {
       logError(`Errow detecting repos setting using git: ${error}`)
     } else {
       throw new Error(
@@ -36,9 +37,7 @@ export function detectProvider(inputs: UploaderInputs, hasToken = false): Partia
   return serviceParams
 }
 
-export function walkProviders(
-  inputs: UploaderInputs,
-): IServiceParams {
+export function walkProviders(inputs: UploaderInputs): IServiceParams {
   for (const provider of providers) {
     if (provider.detect(inputs.environment)) {
       info(`Detected ${provider.getServiceName()} as the CI provider.`)
@@ -56,4 +55,23 @@ export function walkProviders(
     }
   }
   throw new Error(`Unable to detect provider.`)
+}
+
+export function setSlug(
+  slugArg: string,
+  orgEnv: string | undefined,
+  repoEnv: string | undefined,
+): string {
+  if (slugArg !== '') {
+    return slugArg
+  }
+  if (
+    typeof orgEnv !== 'undefined' &&
+    typeof repoEnv !== 'undefined' &&
+    orgEnv !== '' &&
+    repoEnv !== ''
+  ) {
+    return `${orgEnv}/${repoEnv}`
+  }
+  return ''
 }

--- a/src/helpers/provider.ts
+++ b/src/helpers/provider.ts
@@ -58,11 +58,11 @@ export function walkProviders(inputs: UploaderInputs): IServiceParams {
 }
 
 export function setSlug(
-  slugArg: string,
+  slugArg: string | undefined,
   orgEnv: string | undefined,
   repoEnv: string | undefined,
 ): string {
-  if (slugArg !== '') {
+  if (typeof slugArg !== "undefined" && slugArg !== '') {
     return slugArg
   }
   if (

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -14,3 +14,7 @@ export function runExternalProgram(
   }
   return result.stdout.toString().trim()
 }
+
+export function isSetAndNotEmpty(val: string | undefined): boolean {
+  return typeof val !== 'undefined' && val !== ''
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { version } from '../package.json'
 import * as validateHelpers from './helpers/validate'
 import { detectProvider } from './helpers/provider'
 import * as webHelpers from './helpers/web'
-import { info, verbose } from './helpers/logger'
+import { info, logError, verbose } from './helpers/logger'
 import { getToken } from './helpers/token'
 import {
   coverageFilePatterns,
@@ -237,9 +237,18 @@ export async function main(
 
   // == Step 8: either upload or dry-run
 
-  const query = webHelpers.generateQuery(
-    webHelpers.populateBuildParams(inputs, serviceParams),
-  )
+  const buildParams = webHelpers.populateBuildParams(inputs, serviceParams)
+
+  verbose('Using the following upload parameters:', Boolean(args.verbose))
+  for (const parameter in buildParams) {
+    verbose(`${parameter}`, Boolean(args.verbose))
+  }
+
+  if (buildParams.slug !== '' && !buildParams.slug?.match(/\//)) {
+    logError(`Slug must follow the format of "<owner>/<repo>" or be blank. We detected "${buildParams.slug}"`)
+  }
+  
+  const query = webHelpers.generateQuery(buildParams)
 
   if (args.dryRun) {
     return dryRun(uploadHost, token, query, uploadFile, args.source || '')

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export interface UploaderArgs {
   rootDir?: string // Specify the project root directory when not in a git repo
   nonZero?: string // Should errors exit with a non-zero (default: false)
   dryRun?: string // Don't upload files to Codecov
-  slug?: string // Specify the slug manually
+  slug: string // Specify the slug manually
   url?: string // Change the upload host (Enterprise use)
   clean?: string // Move discovered coverage reports to the trash
   feature?: string // Toggle features

--- a/test/helpers/files.test.ts
+++ b/test/helpers/files.test.ts
@@ -52,7 +52,7 @@ describe('File Helpers', () => {
       }
     })
     expect(
-      await fileHelpers.getFileListing('.', { flags: '', verbose: 'true' }),
+      await fileHelpers.getFileListing('.', { flags: '', verbose: 'true', slug: '', }),
     ).toBe(files.join('\n'))
   })
 
@@ -66,7 +66,7 @@ describe('File Helpers', () => {
       }
     })
     expect(
-      await fileHelpers.getFileListing('.', { flags: '', networkFilter: 'package', verbose: 'true' }),
+      await fileHelpers.getFileListing('.', { flags: '', networkFilter: 'package', verbose: 'true', slug: '', }),
     ).toBe(['package.json', 'package-lock.json'].join('\n'))
   })
 
@@ -80,7 +80,7 @@ describe('File Helpers', () => {
       }
     })
     expect(
-      await fileHelpers.getFileListing('.', { flags: '', networkFilter: 'src/', verbose: 'true' }),
+      await fileHelpers.getFileListing('.', { flags: '', networkFilter: 'src/', verbose: 'true', slug: '', }),
     ).toBe(['src/file.js'].join('\n'))
   })
 
@@ -89,7 +89,7 @@ describe('File Helpers', () => {
       return { stdout: '', status: null, error: new Error() }
     })
     expect(
-      await fileHelpers.getFileListing('.', { flags: '', verbose: 'true' }),
+      await fileHelpers.getFileListing('.', { flags: '', verbose: 'true', slug: '', }),
     ).toMatch('npm-shrinkwrap.json')
   })
 
@@ -103,7 +103,7 @@ describe('File Helpers', () => {
       }
     })
     expect(
-      await fileHelpers.getFileListing('.', { flags: '', networkFilter: 'package', networkPrefix: 'build/', verbose: 'true' }),
+      await fileHelpers.getFileListing('.', { flags: '', networkFilter: 'package', networkPrefix: 'build/', verbose: 'true', slug: '', }),
     ).toBe(['build/package.json', 'build/package-lock.json'].join('\n'))
   })
 
@@ -117,7 +117,7 @@ describe('File Helpers', () => {
       }
     })
     expect(
-      await fileHelpers.getFileListing('.', { flags: '', networkFilter: 'src/', networkPrefix: 'build/', verbose: 'true' }),
+      await fileHelpers.getFileListing('.', { flags: '', networkFilter: 'src/', networkPrefix: 'build/', verbose: 'true', slug: '', }),
     ).toBe(['build/src/file.js'].join('\n'))
   })
 
@@ -126,7 +126,7 @@ describe('File Helpers', () => {
       return { stdout: '', status: null, error: new Error() }
     })
     expect(
-      await fileHelpers.getFileListing('.', { flags: '', networkFilter: 'npm', verbose: 'true' }),
+      await fileHelpers.getFileListing('.', { flags: '', networkFilter: 'npm', verbose: 'true', slug: '', }),
     ).toMatch('npm-shrinkwrap.json')
   })
 
@@ -135,7 +135,7 @@ describe('File Helpers', () => {
       return { stdout: '', status: null, error: new Error() }
     })
     expect(
-      await fileHelpers.getFileListing('.', { flags: '', networkFilter: 'src', verbose: 'true' }),
+      await fileHelpers.getFileListing('.', { flags: '', networkFilter: 'src', verbose: 'true', slug: '', }),
     ).toMatch('')
   })
 

--- a/test/helpers/provider.test.ts
+++ b/test/helpers/provider.test.ts
@@ -29,7 +29,8 @@ describe('detectProvider()', () => {
     const inputs: UploaderInputs = {
       args: {
         sha: '1234566',
-        flags: ''
+        flags: '',
+        slug: '',
       },
       environment: {},
     }
@@ -47,7 +48,8 @@ describe('detectProvider()', () => {
     })
     const inputs: UploaderInputs = {
       args: {
-        flags: ''
+        flags: '',
+        slug: '',
       },
       environment: {},
     }
@@ -67,7 +69,8 @@ describe('walkProviders()', () => {
     })
     const inputs: UploaderInputs = {
       args: {
-        flags: ''
+        flags: '',
+        slug: '',
       },
       environment: {},
     }
@@ -78,7 +81,8 @@ describe('walkProviders()', () => {
   it('will return serviceParams if able to detect', () => {
     const inputs: UploaderInputs = {
       args: {
-        flags: ''
+        flags: '',
+        slug: '',
       },
       environment: {
         CI: 'true',
@@ -93,7 +97,7 @@ describe('walkProviders()', () => {
       job: '',
       pr: '',
       service: 'circleci',
-      slug: 'undefined/undefined',
+      slug: '',
     }
     expect(walkProviders(inputs)).toEqual(expectedOutput)
   })

--- a/test/helpers/provider.test.ts
+++ b/test/helpers/provider.test.ts
@@ -1,6 +1,6 @@
 import childProcess from 'child_process'
 import td from 'testdouble'
-import { detectProvider, walkProviders } from '../../src/helpers/provider'
+import { detectProvider, setSlug, walkProviders } from '../../src/helpers/provider'
 import { IServiceParams, UploaderInputs } from '../../src/types'
 
 describe('detectProvider()', () => {
@@ -102,3 +102,27 @@ describe('walkProviders()', () => {
     expect(walkProviders(inputs)).toEqual(expectedOutput)
   })
 })
+
+describe('setSlug()', () => {
+  it('will return an empty string when not correctedly passed values', () => {
+    expect(setSlug(undefined, undefined, undefined)).toEqual('')
+    expect(setSlug(undefined, 'foo', undefined)).toEqual('')
+    expect(setSlug(undefined, undefined, 'bar')).toEqual('')
+  })
+
+  it('will return the args.slug if either orgEnv or repoEnv are not valid', () => {
+    expect(setSlug('baz', undefined, undefined)).toEqual('baz')
+    expect(setSlug('baz', 'foo', undefined)).toEqual('baz')
+    expect(setSlug('baz', undefined, 'bar')).toEqual('baz')  
+  })
+
+  it('will return the args.slug if set and both orgEnv and repoEnv are valid', () => {
+    expect(setSlug('baz', 'foo', 'bar')).toEqual('baz')
+  })
+
+  it('will return orgEnv/epoEnv if args.slug is empty and both orgEnv and repoEnv are valid', () => {
+    expect(setSlug('', 'foo', 'bar')).toEqual('foo/bar')
+  })
+})
+
+

--- a/test/helpers/token.test.ts
+++ b/test/helpers/token.test.ts
@@ -2,7 +2,7 @@ import path from 'path'
 
 import * as fileHelpers from '../../src/helpers/files'
 import * as tokenHelpers from '../../src/helpers/token'
-import { UploaderInputs } from '../../src/types'
+import { UploaderArgs, UploaderInputs } from '../../src/types'
 import { DEFAULT_UPLOAD_HOST } from '../../src/helpers/constansts'
 
 describe('Get tokens', () => {
@@ -21,25 +21,28 @@ describe('Get tokens', () => {
 
   describe('From yaml', () => {
     it('Returns empty with no yaml file', () => {
-      const args = {
+      const args: UploaderArgs = {
         flags: '',
         verbose: 'true',
+        slug: '',
       }
       expect(tokenHelpers.getTokenFromYaml('.', args)).toBe('')
     })
 
     it('Returns the correct token from file', () => {
-      const args = {
+      const args: UploaderArgs = {
         flags: '',
         verbose: 'true',
+        slug: '',
       }
       expect(tokenHelpers.getTokenFromYaml(fixturesDir, args)).toBe('faketoken')
     })
 
     it('Returns deprecation error from codecov_token', () => {
-      const args = {
+      const args: UploaderArgs = {
         flags: '',
         verbose: 'true',
+        slug: '',
       }
       jest.spyOn(console, 'error').mockImplementation(() => {
         // Intentionally empty
@@ -55,7 +58,7 @@ describe('Get tokens', () => {
   describe('From right source', () => {
     it('Returns from args', () => {
       const inputs: UploaderInputs = {
-        args: { token: 'argtoken', flags: '' },
+        args: { token: 'argtoken', flags: '', slug: '', },
         environment: { CODECOV_TOKEN: 'envtoken' },
       }
       expect(tokenHelpers.getToken(inputs, fixturesDir)).toBe('argtoken')
@@ -63,7 +66,7 @@ describe('Get tokens', () => {
 
     it('Returns from env', () => {
       const inputs: UploaderInputs = {
-        args: { flags: '' },
+        args: { flags: '', slug: '', },
         environment: { CODECOV_TOKEN: 'envtoken' },
       }
       expect(tokenHelpers.getToken(inputs, fixturesDir)).toBe('envtoken')
@@ -71,7 +74,7 @@ describe('Get tokens', () => {
 
     it('Returns from env', () => {
       const inputs: UploaderInputs = {
-        args: { flags: '' },
+        args: { flags: '', slug: '', },
         environment: {},
       }
       expect(tokenHelpers.getToken(inputs, fixturesDir)).toBe('faketoken')
@@ -79,7 +82,7 @@ describe('Get tokens', () => {
 
     it('Returns from no source', () => {
       const inputs: UploaderInputs = {
-        args: { flags: '' },
+        args: { flags: '', slug: '', },
         environment: {},
       }
       expect(tokenHelpers.getToken(inputs, '.')).toBe('')
@@ -91,7 +94,8 @@ describe('Get tokens', () => {
       args: {
         url: 'dummy.local',
         token: 'goodToken',
-        flags: ''
+        flags: '',
+        slug: '',
       },
       environment: {
         CODECOV_TOKEN: 'badToken'
@@ -104,7 +108,8 @@ describe('Get tokens', () => {
     const inputs: UploaderInputs = {
       args: {
         url: 'dummy.local',
-        flags: ''
+        flags: '',
+        slug: '',
       },
       environment: {
         CODECOV_TOKEN: 'goodT----oken'
@@ -117,7 +122,8 @@ describe('Get tokens', () => {
     const inputs: UploaderInputs = {
       args: {
         url: DEFAULT_UPLOAD_HOST,
-        flags: ''
+        flags: '',
+        slug: '',
       },
       environment: {
         CODECOV_TOKEN: 'bad------Token'

--- a/test/helpers/web.test.ts
+++ b/test/helpers/web.test.ts
@@ -114,7 +114,7 @@ describe('Web Helpers', () => {
 
   it('can populateBuildParams() from args', () => {
     const result = populateBuildParams(
-      { args: { flags: 'testFlag', tag: 'testTag' }, environment: {} },
+      { args: { flags: 'testFlag', tag: 'testTag', slug: '', }, environment: {} },
       {
         name: '',
         tag: ',',
@@ -134,7 +134,7 @@ describe('Web Helpers', () => {
 
   it('can populateBuildParams() from args with multiple flags as string', () => {
     const result = populateBuildParams(
-      { args: { flags: 'testFlag1,testFlag2', tag: 'testTag' }, environment: {} },
+      { args: { flags: 'testFlag1,testFlag2', tag: 'testTag' , slug: '',}, environment: {} },
       {
         name: '',
         tag: '',
@@ -154,7 +154,7 @@ describe('Web Helpers', () => {
 
   it('can populateBuildParams() from args with multiple flags as list', () => {
     const result = populateBuildParams(
-      { args: { flags: ['testFlag1', 'testFlag2'], tag: 'testTag' }, environment: {} },
+      { args: { flags: ['testFlag1', 'testFlag2'], tag: 'testTag', slug: '', }, environment: {} },
       {
         name: '',
         tag: '',

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -46,7 +46,9 @@ describe('Uploader Core', () => {
   })
 
   it('Can upload with custom name', async () => {
-    jest.spyOn(console, 'log').mockImplementation(() => {})
+    jest.spyOn(console, 'log').mockImplementation(() => {
+      // intentionally empty
+    })
     process.env.CI = 'true'
     process.env.CIRCLECI = 'true'
 
@@ -62,6 +64,7 @@ describe('Uploader Core', () => {
       token: 'abcdefg',
       url: 'https://codecov.io',
       flags: '',
+      slug: '',
     })
     expect(result).toEqual({
       status: 'success',
@@ -73,7 +76,9 @@ describe('Uploader Core', () => {
     process.env.SOMETHING = 'red'
     process.env.ANOTHER = 'blue'
     jest.spyOn(process, 'exit')
-    const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {
+      // intentionally empty
+    })
     await app.main({
       name: 'customname',
       token: 'abcdefg',
@@ -81,6 +86,7 @@ describe('Uploader Core', () => {
       dryRun: 'true',
       env: 'SOMETHING,ANOTHER',
       flags: '',
+      slug: '',
     })
     expect(log).toHaveBeenCalledWith(expect.stringMatching(/SOMETHING=red/))
     expect(log).toHaveBeenCalledWith(expect.stringMatching(/ANOTHER=blue/))
@@ -99,13 +105,16 @@ describe('Uploader Core', () => {
 
     it('Can upload without token', async () => {
       jest.spyOn(process, 'exit')
-      const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+      const log = jest.spyOn(console, 'log').mockImplementation(() => {
+        // intentionally empty
+      })
       await app.main({
         name: 'customname',
         url: 'https://codecov.io',
         dryRun: 'true',
         env: 'SOMETHING,ANOTHER',
         flags: '',
+        slug: '',
       })
       expect(log).toHaveBeenCalledWith(
         expect.stringMatching('-> No token specified or token is empty'),
@@ -131,6 +140,7 @@ describe('Uploader Core', () => {
         url: 'https://codecov.io',
         tag: '',
         source: '',
+        slug: '',
       })
       expect(result).toEqual({
         status: 'success',
@@ -157,6 +167,7 @@ describe('Uploader Core', () => {
       url: 'https://codecov.io',
       parent,
       flags: '',
+      slug: '',
     })
     expect(result).toEqual({
       status: 'success',
@@ -165,13 +176,16 @@ describe('Uploader Core', () => {
   }, 30000)
 
   it('Can find all coverage from root dir', async () => {
-    const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {
+      // intentionally empty
+    })
     await app.main({
       name: 'customname',
       token: 'abcdefg',
       url: 'https://codecov.io',
       dryRun: 'true',
       flags: '',
+      slug: '',
     })
     expect(log).toHaveBeenCalledWith(
       expect.stringMatching(/An example coverage root file/),
@@ -182,7 +196,9 @@ describe('Uploader Core', () => {
   })
 
   it('Can find a single specified file', async () => {
-    const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {
+      // intentionally empty
+    })
     await app.main({
       dryRun: 'true',
       file: 'test/fixtures/coverage.txt',
@@ -190,6 +206,7 @@ describe('Uploader Core', () => {
       token: 'abcdefg',
       url: 'https://codecov.io',
       flags: '',
+      slug: '',
     })
     expect(log).toHaveBeenCalledWith(
       expect.stringMatching(/Processing.*test\/fixtures\/coverage\.txt\.\.\./),
@@ -197,7 +214,9 @@ describe('Uploader Core', () => {
   })
 
   it('Can find multiple specified files', async () => {
-    const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {
+      // intentionally empty
+    })
     await app.main({
       dryRun: 'true',
       file: [
@@ -209,6 +228,7 @@ describe('Uploader Core', () => {
       token: 'abcdefg',
       url: 'https://codecov.io',
       flags: '',
+      slug: '',
     })
     expect(log).toHaveBeenCalledWith(
       expect.stringMatching(/Processing.*test\/fixtures\/coverage\.txt\.\.\./),
@@ -222,7 +242,9 @@ describe('Uploader Core', () => {
   })
 
   it('Can handle glob files', async () => {
-    const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {
+      // intentionally empty
+    })
     await app.main({
       dryRun: 'true',
       file: [
@@ -233,6 +255,7 @@ describe('Uploader Core', () => {
       token: 'abcdefg',
       url: 'https://codecov.io',
       flags: '',
+      slug: '',
     })
     expect(log).toHaveBeenCalledWith(
       expect.stringMatching(/Processing.*test\/fixtures\/coverage\.txt\.\.\./),
@@ -246,7 +269,9 @@ describe('Uploader Core', () => {
   })
 
   it('Can find only coverage from custom dir', async () => {
-    const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {
+      // intentionally empty
+    })
     await app.main({
       name: 'customname',
       token: 'abcdefg',
@@ -254,6 +279,7 @@ describe('Uploader Core', () => {
       dryRun: 'true',
       dir: './test/fixtures/other',
       flags: '',
+      slug: '',
     })
     expect(log).toHaveBeenCalledWith(
       expect.stringMatching(/An example coverage other file/),
@@ -264,7 +290,9 @@ describe('Uploader Core', () => {
   })
 
   it('Can remove coverage files', async () => {
-    const unlink = jest.spyOn(fs, 'unlink').mockImplementation(() => {})
+    const unlink = jest.spyOn(fs, 'unlink').mockImplementation(() => {
+      // intentionally empty
+    })
     await app.main({
       name: 'customname',
       token: 'abcdefg',
@@ -273,6 +301,7 @@ describe('Uploader Core', () => {
       dir: './test/fixtures/other',
       clean: 'true',
       flags: '',
+      slug: '',
     })
     expect(unlink).toHaveBeenCalledWith(
       'test/fixtures/other/coverage.txt',
@@ -281,7 +310,9 @@ describe('Uploader Core', () => {
   })
 
   it('Can include the network', async () => {
-    const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {
+      // intentionally empty
+    })
     await app.main({
       name: 'customname',
       token: 'abcdefg',
@@ -289,6 +320,7 @@ describe('Uploader Core', () => {
       dryRun: 'true',
       dir: './test/fixtures/other',
       flags: '',
+      slug: '',
     })
     expect(log).toHaveBeenCalledWith(expect.stringMatching(/<<<<<< network/))
   })
@@ -301,6 +333,7 @@ describe('Uploader Core', () => {
       dryRun: 'true',
       feature: 'network',
       flags: '',
+      slug: '',
     })
     expect(console.log).not.toHaveBeenCalledWith(
       expect.stringMatching(/<<<<<< network/),

--- a/test/providers/provider_appveyorci.test.ts
+++ b/test/providers/provider_appveyorci.test.ts
@@ -16,6 +16,7 @@ describe('AppveyorCI Params', () => {
           url: '',
           source: '',
           flags: '',
+          slug: '',
         },
         environment: {},
       }
@@ -43,7 +44,8 @@ describe('AppveyorCI Params', () => {
     it('does run with AppveyorCI env variable', () => {
       const inputs : UploaderInputs= {
         args: {
-          flags: ''
+          flags: '',
+          slug: '',
         },
         environment: {
           CI: 'true',
@@ -62,6 +64,7 @@ describe('AppveyorCI Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         APPVEYOR: 'true',

--- a/test/providers/provider_azurepipelines.test.ts
+++ b/test/providers/provider_azurepipelines.test.ts
@@ -17,6 +17,7 @@ describe('Azure Pipelines CI Params', () => {
           url: '',
           source: '',
           flags: '',
+          slug: '',
         },
         environment: {},
       }
@@ -31,6 +32,7 @@ describe('Azure Pipelines CI Params', () => {
           url: '',
           source: '',
           flags: '',
+          slug: '',
         },
         environment: {
           SYSTEM_TEAMFOUNDATIONSERVERURI: 'true',
@@ -48,6 +50,7 @@ describe('Azure Pipelines CI Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         SYSTEM_TEAMFOUNDATIONSERVERURI: 'https://example.azure.com',
@@ -81,6 +84,7 @@ describe('Azure Pipelines CI Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         BUILD_BUILDNUMBER: '1',
@@ -118,6 +122,7 @@ describe('Azure Pipelines CI Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         BUILD_BUILDNUMBER: '1',
@@ -155,6 +160,7 @@ describe('Azure Pipelines CI Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         BUILD_BUILDNUMBER: '1',
@@ -197,6 +203,7 @@ describe('Azure Pipelines CI Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         BUILD_BUILDNUMBER: '1',

--- a/test/providers/provider_bitbucket.test.ts
+++ b/test/providers/provider_bitbucket.test.ts
@@ -16,6 +16,7 @@ describe('Bitbucket Params', () => {
           url: '',
           source: '',
           flags: '',
+          slug: '',
         },
         environment: {},
       }
@@ -30,7 +31,8 @@ describe('Bitbucket Params', () => {
     it('does not run without Bitbucket env variable', () => {
       const inputs: UploaderInputs = {
         args: {
-          flags: ''
+          flags: '',
+          slug: '',
         },
         environment: {
           BITBUCKET_BUILD_NUMBER: '1',
@@ -49,6 +51,7 @@ describe('Bitbucket Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         BITBUCKET_BUILD_NUMBER: '1',
@@ -76,6 +79,7 @@ describe('Bitbucket Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         BITBUCKET_BRANCH: 'main',
@@ -107,6 +111,7 @@ describe('Bitbucket Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         BITBUCKET_BRANCH: 'main',
@@ -137,6 +142,7 @@ describe('Bitbucket Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         BITBUCKET_BRANCH: 'main',

--- a/test/providers/provider_buildkite.test.ts
+++ b/test/providers/provider_buildkite.test.ts
@@ -9,18 +9,22 @@ describe('Buildkite Params', () => {
 
   describe('detect()', () => {
     it('does not run without Buildkite env variable', () => {
-      const inputs = {
-        args: {},
-        envs: {},
+      const inputs: UploaderInputs = {
+        args: {
+          flags: '',
+          slug: '',
+        },
+        environment: {},
       }
-      const detected = providerBuildkite.detect(inputs.envs)
+      const detected = providerBuildkite.detect(inputs.environment)
       expect(detected).toBeFalsy()
     })
 
     it('does not run without Buildkite env variable', () => {
       const inputs: UploaderInputs = {
         args: {
-          flags: ''
+          flags: '',
+          slug: '',
         },
         environment: {
           BUILDKITE: 'true',
@@ -38,11 +42,13 @@ describe('Buildkite Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         BUILDKITE: 'true',
         BUILDKITE_BUILD_NUMBER: '1',
         BUILDKITE_JOB_ID: '3',
+        BUILDKITE_ORGANIZATION_SLUG: 'testOrg',
         BUILDKITE_PIPELINE_SLUG: 'testRepo',
         BUILDKITE_BRANCH: 'main',
         BUILDKITE_COMMIT: 'testingsha',
@@ -58,7 +64,7 @@ describe('Buildkite Params', () => {
       job: '3',
       pr: '',
       service: 'buildkite',
-      slug: 'testRepo',
+      slug: 'testOrg/testRepo',
     }
     const params = providerBuildkite.getServiceParams(inputs)
     expect(params).toMatchObject(expected)

--- a/test/providers/provider_circleci.test.ts
+++ b/test/providers/provider_circleci.test.ts
@@ -12,7 +12,8 @@ describe('CircleCI Params', () => {
     it('does not run without CircleCI env variable', () => {
       const inputs: UploaderInputs = {
         args: {
-          flags: ''
+          flags: '',
+          slug: '',
         },
         environment: {},
       }
@@ -23,7 +24,8 @@ describe('CircleCI Params', () => {
     it('does run with CircleCI env variable', () => {
       const inputs: UploaderInputs = {
         args: {
-          flags: ''
+          flags: '',
+          slug: '',
         },
         environment: {
           CI: 'true',
@@ -39,6 +41,7 @@ describe('CircleCI Params', () => {
     const inputs: UploaderInputs = {
       args: {
         flags: '',
+        slug: '',
       },
       environment: {
         CI: 'true',
@@ -71,6 +74,7 @@ describe('CircleCI Params', () => {
     const inputs: UploaderInputs = {
       args: {
         flags: '',
+        slug: '',
       },
       environment: {
         CI: 'true',

--- a/test/providers/provider_cirrus.test.ts
+++ b/test/providers/provider_cirrus.test.ts
@@ -12,7 +12,8 @@ describe('Cirrus Params', () => {
     it('does not run without Cirrus env variable', () => {
       const inputs: UploaderInputs = {
         args: {
-          flags: ''
+          flags: '',
+          slug: '',
         },
         environment: {},
       }
@@ -40,6 +41,7 @@ describe('Cirrus Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         CI: 'true',
@@ -48,7 +50,8 @@ describe('Cirrus Params', () => {
         CIRRUS_CHANGE_IN_REPO: 'testingsha',
         CIRRUS_BUILD_ID: '2',
         CIRRUS_PR: '1',
-        CIRRUS_REPO_FULL_NAME: 'https:/example.com/repo',
+        CIRRUS_REPO_OWNER: 'testOrg',
+        CIRRUS_REPO_NAME: 'testRepo',
       },
     }
     const expected: IServiceParams = {
@@ -59,7 +62,7 @@ describe('Cirrus Params', () => {
       job: '',
       pr: '1',
       service: 'cirrus-ci',
-      slug: 'https:/example.com/repo',
+      slug: 'testOrg/testRepo',
     }
     const params = providerCirrus.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
@@ -85,7 +88,8 @@ describe('Cirrus Params', () => {
         CIRRUS_CHANGE_IN_REPO: 'testingsha',
         CIRRUS_BUILD_ID: '2',
         CIRRUS_PR: '1',
-        CIRRUS_REPO_FULL_NAME: 'https:/example.com/repo',
+        CIRRUS_REPO_OWNER: 'testOrg',
+        CIRRUS_REPO_NAME: 'testRepo',
       },
     }
     const expected: IServiceParams = {

--- a/test/providers/provider_codebuild.test.ts
+++ b/test/providers/provider_codebuild.test.ts
@@ -25,6 +25,7 @@ describe('CodeBuild Params', () => {
           source: '',
           url: '',
           flags: '',
+          slug: '',
         },
         environment: {
           CI: 'true',
@@ -44,6 +45,7 @@ describe('CodeBuild Params', () => {
           source: '',
           url: '',
           flags: '',
+          slug: '',
         },
         environment: {
           CI: 'true',

--- a/test/providers/provider_drone.test.ts
+++ b/test/providers/provider_drone.test.ts
@@ -38,6 +38,7 @@ describe('Drone Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         CI: 'true',
@@ -47,7 +48,7 @@ describe('Drone Params', () => {
         DRONE_BUILD_NUMBER: '2',
         DRONE_PULL_REQUEST: '1',
         DRONE_BUILD_URL: 'https://www.drone.io/',
-        DRONE_REPO: 'repo',
+        DRONE_REPO: 'testOrg/testRepo',
       },
     }
     const expected: IServiceParams = {
@@ -58,7 +59,7 @@ describe('Drone Params', () => {
       job: '',
       pr: '1',
       service: 'drone.io',
-      slug: 'repo',
+      slug: 'testOrg/testRepo',
     }
     const params = providerDrone.getServiceParams(inputs)
     expect(params).toMatchObject(expected)

--- a/test/providers/provider_githubactions.test.ts
+++ b/test/providers/provider_githubactions.test.ts
@@ -14,6 +14,7 @@ describe('GitHub Actions Params', () => {
       const inputs: UploaderInputs = {
         args: {
           flags: '',
+          slug: '',
         },
         environment: {
           GITHUB_REF: 'refs/heads/master',
@@ -46,6 +47,7 @@ describe('GitHub Actions Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         GITHUB_ACTIONS: 'true',
@@ -79,6 +81,7 @@ describe('GitHub Actions Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         GITHUB_ACTIONS: 'true',
@@ -120,6 +123,7 @@ describe('GitHub Actions Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         GITHUB_ACTIONS: 'true',
@@ -200,6 +204,7 @@ describe('GitHub Actions Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         GITHUB_ACTIONS: 'true',

--- a/test/providers/provider_gitlabci.test.ts
+++ b/test/providers/provider_gitlabci.test.ts
@@ -11,11 +11,13 @@ describe('GitLabCI Params', () => {
 
   describe('detect()', () => {
     it('does not run without GitLabCI env variable', () => {
-      const inputs = {
-        args: {},
-        envs: {},
+      const inputs: UploaderInputs = {
+        args: {
+          flags: '', slug: '',
+        },
+        environment: {},
       }
-      const detected = providerGitLabci.detect(inputs.envs)
+      const detected = providerGitLabci.detect(inputs.environment)
       expect(detected).toBeFalsy()
     })
 
@@ -40,6 +42,7 @@ describe('GitLabCI Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         GITLAB_CI: 'true',
@@ -70,6 +73,7 @@ describe('GitLabCI Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         CI_BUILD_ID: '1',
@@ -103,6 +107,7 @@ describe('GitLabCI Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         CI_COMMIT_REF_NAME: 'master',
@@ -133,6 +138,7 @@ describe('GitLabCI Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         GITLAB_CI: 'true',

--- a/test/providers/provider_herokuci.test.ts
+++ b/test/providers/provider_herokuci.test.ts
@@ -13,7 +13,8 @@ describe('HerokuCI Params', () => {
     it('does not run without HerokuCI env variable', () => {
       const inputs: UploaderInputs = {
         args: {
-          flags: ''
+          flags: '',
+          slug: '',
         },
         environment: {},
       }
@@ -24,7 +25,8 @@ describe('HerokuCI Params', () => {
     it('does run with Herokuci env variable', () => {
       const inputs: UploaderInputs= {
         args: {
-          flags: ''
+          flags: '',
+          slug: '',
         },
         environment: {
           CI: 'true',
@@ -39,7 +41,7 @@ describe('HerokuCI Params', () => {
   // This should test that the provider outputs proper default values
   it('gets the correct params on no env variables', () => {
     const inputs: UploaderInputs = {
-      args: { tag: '', url: '', source: '', flags: '' },
+      args: { tag: '', url: '', source: '', flags: '', slug: '', },
       environment: {},
     }
     const expected: IServiceParams = {
@@ -63,7 +65,7 @@ describe('HerokuCI Params', () => {
   // This should test that the provider outputs proper parameters when a push event is created
   it('gets the correct params on push', () => {
     const inputs: UploaderInputs = {
-      args: { tag: '', url: '', source: '', flags: '' },
+      args: { tag: '', url: '', source: '', flags: '', slug: '', },
       environment: {
         CI: 'true',
         HEROKU_TEST_RUN_BRANCH: 'testBranch',

--- a/test/providers/provider_jenkinsci.test.ts
+++ b/test/providers/provider_jenkinsci.test.ts
@@ -17,6 +17,7 @@ describe('Jenkins CI Params', () => {
           url: '',
           source: '',
           flags: '',
+          slug: '',
         },
         environment: {},
       }
@@ -29,13 +30,16 @@ describe('Jenkins CI Params', () => {
     })
 
     it('does run with JenkinsCI env variable', () => {
-      const inputs = {
-        args: {},
-        envs: {
+      const inputs: UploaderInputs = {
+        args: {
+          flags: '',
+          slug: '',
+        },
+        environment: {
           JENKINS_URL: 'https://example.jenkins.com',
         },
       }
-      const detected = providerJenkinsci.detect(inputs.envs)
+      const detected = providerJenkinsci.detect(inputs.environment)
       expect(detected).toBeTruthy()
     })
   })
@@ -47,6 +51,7 @@ describe('Jenkins CI Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         BUILD_NUMBER: '1',
@@ -82,6 +87,7 @@ describe('Jenkins CI Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         BUILD_NUMBER: '1',

--- a/test/providers/provider_local.test.ts
+++ b/test/providers/provider_local.test.ts
@@ -60,6 +60,7 @@ describe('Local Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {},
     }
@@ -92,6 +93,7 @@ describe('Local Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {},
     }

--- a/test/providers/provider_teamcity.test.ts
+++ b/test/providers/provider_teamcity.test.ts
@@ -13,7 +13,8 @@ describe('TeamCity Params', () => {
     it('does not run without TeamCity env variable', () => {
       const inputs: UploaderInputs = {
         args: {
-          flags: ''
+          flags: '',
+          slug: '',
         },
         environment: {},
       }
@@ -27,7 +28,8 @@ describe('TeamCity Params', () => {
           tag: '',
           url: '',
           source: '',
-          flags: ''
+          flags: '',
+          slug: '',
         },
         environment: {
           CI: 'true',
@@ -46,6 +48,7 @@ describe('TeamCity Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         CI: 'true',
@@ -80,6 +83,7 @@ describe('TeamCity Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         CI: 'true',

--- a/test/providers/provider_template.test.ts
+++ b/test/providers/provider_template.test.ts
@@ -16,7 +16,8 @@ describe('<Ci> Params', () => {
     it('does not run without <Ci> env variable', () => {
       const inputs: UploaderInputs = {
         args: {
-          flags: ''
+          flags: '',
+          slug: '',
         },
         environment: {},
       }
@@ -29,7 +30,8 @@ describe('<Ci> Params', () => {
     it('does not run without <Ci> env variable', () => {
       const inputs: UploaderInputs= {
         args: {
-          flags: ''
+          flags: '',
+          slug: '',
         },
         environment: {},
       }
@@ -43,7 +45,7 @@ describe('<Ci> Params', () => {
   // This should test that the provider outputs proper default values
   it('gets the correct params on no env variables', () => {
     const inputs: UploaderInputs = {
-      args: { tag: '', url: '', source: '', flags: '' },
+      args: { tag: '', url: '', source: '', flags: '', slug: '', },
       environment: {},
     }
     const expected: IServiceParams = {
@@ -65,7 +67,7 @@ describe('<Ci> Params', () => {
   // This should test that the provider outputs proper parameters when a push event is created
   it('gets the correct params on push', () => {
     const inputs: UploaderInputs = {
-      args: { tag: '', url: '', source: '', flags: '' },
+      args: { tag: '', url: '', source: '', flags: '', slug: '', },
       environment: {},
     }
     const expected: IServiceParams = {
@@ -92,6 +94,7 @@ describe('<Ci> Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {},
     }
@@ -119,6 +122,7 @@ describe('<Ci> Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {},
     }

--- a/test/providers/provider_travisci.test.ts
+++ b/test/providers/provider_travisci.test.ts
@@ -16,6 +16,7 @@ describe('TravisCI Params', () => {
           url: '',
           source: '',
           flags: '',
+          slug: '',
         },
         environment: {},
       }
@@ -38,7 +39,8 @@ describe('TravisCI Params', () => {
     it('does run with TravisCI env variable', () => {
       const inputs: UploaderInputs = {
         args: {
-          flags: ''
+          flags: '',
+          slug: '',
         },
         environment: {
           CI: 'true',
@@ -57,6 +59,7 @@ describe('TravisCI Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         CI: 'true',
@@ -91,6 +94,7 @@ describe('TravisCI Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         CI: 'true',
@@ -127,6 +131,7 @@ describe('TravisCI Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         CI: 'true',

--- a/test/providers/provider_wercker.test.ts
+++ b/test/providers/provider_wercker.test.ts
@@ -1,7 +1,7 @@
 import td from 'testdouble'
 
 import * as providerWercker from '../../src/ci_providers/provider_wercker'
-import { IServiceParams, UploaderArgs, UploaderInputs } from '../../src/types'
+import { IServiceParams, UploaderInputs } from '../../src/types'
 
 describe('Wercker CI Params', () => {
   afterEach(() => {
@@ -13,6 +13,7 @@ describe('Wercker CI Params', () => {
       const inputs: UploaderInputs = {
         args: {
           flags: '',
+          slug: '',
         },
         environment: {},
       }
@@ -24,6 +25,7 @@ describe('Wercker CI Params', () => {
       const inputs: UploaderInputs = {
         args: {
           flags: '',
+          slug: '',
         },
         environment: {
           CI: 'true',
@@ -42,6 +44,7 @@ describe('Wercker CI Params', () => {
         url: '',
         source: '',
         flags: '',
+        slug: '',
       },
       environment: {
         CI: 'true',


### PR DESCRIPTION
- fixes #488 
- improves #252 (removes message)
- partly addresses #197 

General notes:

* makes `slug` mandatory , with an empty default
* audits all providers to ensure that slug returned is either format `<org>/<repo>` or an empty string 
* * this is aided by a new helper method called setSlug
* corrects provider detection cases where incorrect environment variables were being sourced to meet the required slug format
* some file changes may be formatting only