### PR TITLE
Fix: Don't collect scripts as coverage files

### DIFF
--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -334,7 +334,7 @@ export function removeFile(projectRoot: string, filePath: string): void {
   })
 }
 export function getBlocklist(): string[] {
-  return [...manualBlocklist(), ...globBlocklist()]
+  return [...manualBlocklist(), ...globBlocklist()].map(p => '**/' + p)
 }
 
 export function cleanCoverageFilePaths(projectRoot: string, paths: string[], ignoreGlobs: string[]): string[] {

--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -334,7 +334,7 @@ export function removeFile(projectRoot: string, filePath: string): void {
   })
 }
 export function getBlocklist(): string[] {
-  return [...manualBlocklist(), ...globBlocklist()].map(p => '**/' + p)
+  return [...manualBlocklist(), ...globBlocklist()].map(globstar)
 }
 
 export function cleanCoverageFilePaths(projectRoot: string, paths: string[], ignoreGlobs: string[]): string[] {

--- a/test/fixtures/codecov.ps1
+++ b/test/fixtures/codecov.ps1
@@ -1,0 +1,1 @@
+Not a coverage file

--- a/test/fixtures/codecov.sh
+++ b/test/fixtures/codecov.sh
@@ -1,0 +1,1 @@
+Not a coverage file

--- a/test/fixtures/other/codecov.ps1
+++ b/test/fixtures/other/codecov.ps1
@@ -1,0 +1,1 @@
+Not a coverage file

--- a/test/fixtures/other/codecov.sh
+++ b/test/fixtures/other/codecov.sh
@@ -1,0 +1,1 @@
+Not a coverage file

--- a/test/helpers/files.test.ts
+++ b/test/helpers/files.test.ts
@@ -294,7 +294,8 @@ describe('File Helpers', () => {
     })
 
     it("returns the input array when passed an empty ignore array", async() => {
-      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await paths, [])).toEqual(paths)
+      const pathsSync = await paths
+      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), pathsSync, [])).toEqual(pathsSync)
     })
 
     it("ignores an ignore filename", async() => {

--- a/test/helpers/files.test.ts
+++ b/test/helpers/files.test.ts
@@ -228,13 +228,13 @@ describe('File Helpers', () => {
 
     it('can return a list of coverage files with a pattern', async () => {
       expect(
-        await fileHelpers.getCoverageFiles('.', ['index.test.ts']),
-      ).toStrictEqual(['test/index.test.ts', 'test/providers/index.test.ts'])
+        await fileHelpers.getCoverageFiles('.', ['coverage.txt']),
+      ).toStrictEqual(['test/fixtures/coverage.txt', 'test/fixtures/other/coverage.txt'])
     })
     it('can return a list of coverage files with a negated pattern', async () => {
       expect(
-        await fileHelpers.getCoverageFiles('.', ['index.test.ts', '!test/providers']),
-      ).toStrictEqual(['test/index.test.ts'])
+        await fileHelpers.getCoverageFiles('.', ['coverage.txt', '!test/fixtures/other']),
+      ).toStrictEqual(['test/fixtures/coverage.txt'])
     })
     describe('coverage file patterns', () => {
       it('contains `jacoco*.xml`', () => {

--- a/test/helpers/files.test.ts
+++ b/test/helpers/files.test.ts
@@ -2,6 +2,7 @@ import td from 'testdouble'
 import fs from 'fs'
 import childProcess from 'child_process'
 import * as fileHelpers from '../../src/helpers/files'
+import { getBlocklist } from '../../src/helpers/files'
 import mock from 'mock-fs'
 
 describe('File Helpers', () => {
@@ -282,43 +283,42 @@ describe('File Helpers', () => {
   })
 
   describe("cleanCoverageFilePaths()", () => {
-    const ignoreGlobs = fileHelpers.getBlocklist()
-    const paths = fileHelpers.getCoverageFiles(
+    const getPaths = () => fileHelpers.getCoverageFiles(
       '.',
       fileHelpers.coverageFilePatterns(),
     )
     it("works", async () => {
-      const pathsSync = await paths
+      const paths = await getPaths()
 
-      expect(() => fileHelpers.cleanCoverageFilePaths(process.cwd(), pathsSync, ignoreGlobs)).not.toThrow()
+      expect(() => fileHelpers.cleanCoverageFilePaths(process.cwd(), paths, getBlocklist())).not.toThrow()
     })
 
-    it("returns the input array when passed an empty ignore array", async() => {
-      const pathsSync = await paths
-      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), pathsSync, [])).toEqual(pathsSync)
+    it("returns the input array when passed an empty ignore array", async () => {
+      const paths = await getPaths()
+      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), paths, [])).toEqual(paths)
     })
 
-    it("ignores an ignore filename", async() => {
-      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await paths, ["coverage-summary.json"])).not.toContain(expect.stringContaining('coverage-summary.json'))
+    it("ignores an ignore filename", async () => {
+      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await getPaths(), ["coverage-summary.json"])).not.toContain(expect.stringContaining('coverage-summary.json'))
     })
 
-    it("ignores an ignore filename glob", async() => {
-      const foo = expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await paths, ["**/coverage*"])).not.toContainEqual(expect.stringMatching('/coverage'))
+    it("ignores an ignore filename glob", async () => {
+      const foo = expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await getPaths(), ["**/coverage*"])).not.toContainEqual(expect.stringMatching('/coverage'))
       console.log(foo)
     })
 
-    it("ignores an ignore filename globstar", async() => {
-      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await paths, ["**/other/*"])).not.toContainEqual(expect.stringMatching('other'))
+    it("ignores an ignore filename globstar", async () => {
+      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await getPaths(), ["**/other/*"])).not.toContainEqual(expect.stringMatching('other'))
     })
-    
-    it("ignores shell scripts by default", async() => {
-      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await paths, ignoreGlobs)).not.toContainEqual(expect.stringMatching('codecov.sh'))
+
+    it("ignores shell scripts by default", async () => {
+      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await getPaths(), getBlocklist())).not.toContainEqual(expect.stringMatching('codecov.sh'))
     })
-    it("ignores powershell scripts by default", async() => {
-      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await paths, ignoreGlobs)).not.toContainEqual(expect.stringMatching('codecov.ps1'))
+    it("ignores powershell scripts by default", async () => {
+      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await getPaths(), getBlocklist())).not.toContainEqual(expect.stringMatching('codecov.ps1'))
     })
-    it("ignores codecov configs by default", async() => {
-      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await paths, ignoreGlobs)).not.toContainEqual(expect.stringMatching(/^\.?codecov\.ya?ml/))
+    it("ignores codecov configs by default", async () => {
+      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await getPaths(), getBlocklist())).not.toContainEqual(expect.stringMatching(/^\.?codecov\.ya?ml/))
     })
   })
 

--- a/test/helpers/files.test.ts
+++ b/test/helpers/files.test.ts
@@ -303,7 +303,7 @@ describe('File Helpers', () => {
     })
 
     it("ignores an ignore filename glob", async() => {
-      const foo = expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await paths, ["**/coverage*"])).not.toContainEqual(expect.stringMatching('coverage'))
+      const foo = expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await paths, ["**/coverage*"])).not.toContainEqual(expect.stringMatching('/coverage'))
       console.log(foo)
     })
 

--- a/test/helpers/files.test.ts
+++ b/test/helpers/files.test.ts
@@ -282,47 +282,42 @@ describe('File Helpers', () => {
   })
 
   describe("cleanCoverageFilePaths()", () => {
+    const ignoreGlobs = fileHelpers.getBlocklist()
+    const paths = fileHelpers.getCoverageFiles(
+      '.',
+      fileHelpers.coverageFilePatterns(),
+    )
     it("works", async () => {
-      const paths = await fileHelpers.getCoverageFiles(
-        '.',
-        fileHelpers.coverageFilePatterns(),
-      )
-      const ignoreGlobs = fileHelpers.getBlocklist()
+      const pathsSync = await paths
 
-      expect(() => fileHelpers.cleanCoverageFilePaths(process.cwd(), paths, ignoreGlobs)).not.toThrow()
+      expect(() => fileHelpers.cleanCoverageFilePaths(process.cwd(), pathsSync, ignoreGlobs)).not.toThrow()
     })
 
     it("returns the input array when passed an empty ignore array", async() => {
-      const paths = await fileHelpers.getCoverageFiles(
-        '.',
-        fileHelpers.coverageFilePatterns(),
-      )
-      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), paths, [])).toEqual(paths)
+      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await paths, [])).toEqual(paths)
     })
 
     it("ignores an ignore filename", async() => {
-      const paths = await fileHelpers.getCoverageFiles(
-        '.',
-        fileHelpers.coverageFilePatterns(),
-      )
-      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), paths, ["coverage-summary.json"])).not.toContain(expect.stringContaining('coverage.txt'))
+      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await paths, ["coverage-summary.json"])).not.toContain(expect.stringContaining('coverage-summary.json'))
     })
 
     it("ignores an ignore filename glob", async() => {
-      const paths = await fileHelpers.getCoverageFiles(
-        '.',
-        fileHelpers.coverageFilePatterns(),
-      )
-      const foo = expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), paths, ["**/coverage*"])).not.toContainEqual(expect.stringMatching('coverage-summary.json'))
+      const foo = expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await paths, ["**/coverage*"])).not.toContainEqual(expect.stringMatching('coverage'))
       console.log(foo)
     })
 
     it("ignores an ignore filename globstar", async() => {
-      const paths = await fileHelpers.getCoverageFiles(
-        '.',
-        fileHelpers.coverageFilePatterns(),
-      )
-      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), paths, ["**/other/*"])).not.toContainEqual(expect.stringMatching('other'))
+      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await paths, ["**/other/*"])).not.toContainEqual(expect.stringMatching('other'))
+    })
+    
+    it("ignores shell scripts by default", async() => {
+      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await paths, ignoreGlobs)).not.toContainEqual(expect.stringMatching('codecov.sh'))
+    })
+    it("ignores powershell scripts by default", async() => {
+      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await paths, ignoreGlobs)).not.toContainEqual(expect.stringMatching('codecov.ps1'))
+    })
+    it("ignores codecov configs by default", async() => {
+      expect(fileHelpers.cleanCoverageFilePaths(process.cwd(), await paths, ignoreGlobs)).not.toContainEqual(expect.stringMatching(/^\.?codecov\.ya?ml/))
     })
   })
 


### PR DESCRIPTION
- Add tests to check that scripts and config files are removed from coverage files by default: I expect this to fail, see #529
- Add the missing subdir globstar