### PR TITLE
ci: vendor ghr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -451,13 +451,6 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Install GHR
-          command: >
-            wget
-            https://github.com/tcnksm/ghr/releases/download/v0.5.4/ghr_v0.5.4_linux_amd64.zip
-
-            unzip ghr_v0.5.4_linux_amd64.zip
-      - run:
           name: Make binaries executable
           command: |
             chmod +x out/*
@@ -471,7 +464,7 @@ jobs:
 
             echo $RELEASE_TAG > release_tag
 
-            ./ghr -u codecov -r uploader $RELEASE_TAG out
+            vendor/ghr -u codecov -r uploader $RELEASE_TAG out
 
       - persist_to_workspace:
           root: .

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,0 +1,3 @@
+# Third-party Vendor tools
+
+- ghr - Downloaded from https://github.com/tcnksm/ghr/releases/download/v0.5.4/ghr_v0.5.4_linux_amd64.zip on 29 Decenber 2021 - used for creating the GitHub release


### PR DESCRIPTION
after discovering that github releases may not be immutable,
we are vendoring the ghr binary