### PR TITLE
fix: include coverage files

### DIFF
--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -337,7 +337,7 @@ export function getBlocklist(): string[] {
 }
 
 export function filterFilesAgainstBlockList(paths: string[], ignoreGlobs: string[]): string[] {
-  return micromatch.not(paths, ignoreGlobs, {contains: true, windows: true})
+  return micromatch.not(paths, ignoreGlobs, {windows: true})
 }
 
 export function cleanCoverageFilePaths(projectRoot: string, paths: string[]): string[] {

--- a/test/helpers/files.test.ts
+++ b/test/helpers/files.test.ts
@@ -320,6 +320,15 @@ describe('File Helpers', () => {
     it("ignores codecov configs by default", async () => {
       expect(fileHelpers.filterFilesAgainstBlockList(await getPaths(), getBlocklist())).not.toContainEqual(expect.stringMatching(/^\.?codecov\.ya?ml/))
     })
+
+    it.each([
+      "coverage.info",
+      "coverage.opencover.xml",
+      "gap-coverage.json",
+    ])("includes %s", (file) => {
+      expect(fileHelpers.filterFilesAgainstBlockList([file], getBlocklist()))
+        .toContainEqual(expect.stringMatching(file))
+    })
   })
 
   it('can remove a file', () => {


### PR DESCRIPTION
`contains` was inadvertently passed as an option to micromatch in [`filterFilesAgainstBlockList`]:

https://github.com/codecov/uploader/blob/7a9a54e245e629c9a1c8891352cf6941ae4d2496/src/helpers/files.ts#L339-L341

https://github.com/codecov/uploader/pull/577#discussion_r787846281

Tests now specifically cover the following files:

- coverage.info[^1]
- coverage.opencover.xml[^2]
- gap-coverage.json[^3]

[`filterFilesAgainstBlockList`]: https://github.com/codecov/uploader/blob/7a9a54e245e629c9a1c8891352cf6941ae4d2496/src/helpers/files.ts#L339-L341

[^1]: https://github.com/codecov/uploader/issues/614#issuecomment-1030237895
[^2]: https://github.com/codecov/uploader/issues/614#issuecomment-1030371776
[^3]: https://github.com/codecov/uploader/issues/614#issuecomment-1030662555