### PR TITLE
chore: mark npm-shrinkwrap.json as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+npm-shrinkwrap.json -diff


### PR DESCRIPTION
This will tell diff to note that it has changed only, and not attempt to find all changes in diffs and patches.