### PR TITLE
chore: update machine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,7 +493,8 @@ jobs:
             gcloud pubsub topics publish $GCLOUD_UPLOADER_PUBSUB_TOPIC --message '{"release":"'"$RELEASE_TAG"'", "latest":true}'
 
   standards-coverage-comparison:
-    machine: true
+    machine: 
+      image: ubuntu-2004:202201-02
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
As recommended  by https://web.archive.org/web/20220216131451/https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/

> If you have specified an Ubuntu 14.04-based image or you are using machine: true in your config file, please see our [migration guide](https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/) to upgrade to a newer version of Ubuntu image in order to avoid any service disruption during the brownout & subsequent EOL.