### PR TITLE
Fix detection of merge commits on Github Actions an AzP

### DIFF
--- a/src/ci_providers/provider_azurepipelines.ts
+++ b/src/ci_providers/provider_azurepipelines.ts
@@ -60,7 +60,7 @@ function _getSHA(inputs: UploaderInputs): string {
   if (_getPR(inputs)) {
     const mergeCommitRegex = /^[a-z0-9]{40} [a-z0-9]{40}$/
     const mergeCommitMessage = childProcess
-      .execFileSync('git', ['show', '--no-patch', '--format="%P"'])
+      .execFileSync('git', ['show', '--no-patch', '--format=%P'])
       .toString()
       .trimRight()
     if (mergeCommitRegex.exec(mergeCommitMessage)) {

--- a/src/ci_providers/provider_githubactions.ts
+++ b/src/ci_providers/provider_githubactions.ts
@@ -73,7 +73,7 @@ function _getSHA(inputs: UploaderInputs): string {
   let commit = envs.GITHUB_SHA
   if (pr) {
     const mergeCommitRegex = /^[a-z0-9]{40} [a-z0-9]{40}$/
-    const mergeCommitMessage = runExternalProgram('git', ['show', '--no-patch', '--format="%P"'])
+    const mergeCommitMessage = runExternalProgram('git', ['show', '--no-patch', '--format=%P'])
     UploadLogger.verbose(`Handling PR with parent hash(es) '${mergeCommitMessage}' of current commit.`)
     if (mergeCommitRegex.exec(mergeCommitMessage)) {
       const mergeCommit = mergeCommitMessage.split(' ')[1]

--- a/test/providers/provider_azurepipelines.test.ts
+++ b/test/providers/provider_azurepipelines.test.ts
@@ -140,7 +140,6 @@ describe('Azure Pipelines CI Params', () => {
       environment: {
         BUILD_BUILDNUMBER: '1',
         BUILD_BUILDID: '2',
-        BUILD_REPOSITORY_NAME: 'testOrg/testRepo',
         BUILD_SOURCEBRANCH: 'refs/heads/main',
         BUILD_SOURCEVERSION: 'testingsha',
         SYSTEM_BUILD_BUILDID: '1',

--- a/test/providers/provider_azurepipelines.test.ts
+++ b/test/providers/provider_azurepipelines.test.ts
@@ -187,7 +187,7 @@ describe('Azure Pipelines CI Params', () => {
     }
     const execFileSync = td.replace(childProcess, 'execFileSync')
     td.when(
-      execFileSync('git', ['show', '--no-patch', '--format="%P"']),
+      execFileSync('git', ['show', '--no-patch', '--format=%P']),
     ).thenReturn(
       'testingsha123456789012345678901234567890 testingmergecommitsha2345678901234567890',
     )

--- a/test/providers/provider_azurepipelines.test.ts
+++ b/test/providers/provider_azurepipelines.test.ts
@@ -87,6 +87,12 @@ describe('Azure Pipelines CI Params', () => {
       service: 'azure_pipelines',
       slug: 'testOrg/testRepo',
     }
+    const execFileSync = td.replace(childProcess, 'execFileSync')
+    td.when(
+      execFileSync('git', ['show', '--no-patch', '--format=%P']),
+    ).thenReturn(
+      'nonmergesha23456789012345678901234567890',
+    )
     const params = providerAzurepipelines.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
   })
@@ -118,6 +124,12 @@ describe('Azure Pipelines CI Params', () => {
       service: 'azure_pipelines',
       slug: 'testOrg/testRepo',
     }
+    const execFileSync = td.replace(childProcess, 'execFileSync')
+    td.when(
+      execFileSync('git', ['show', '--no-patch', '--format=%P']),
+    ).thenReturn(
+      'nonmergesha23456789012345678901234567890',
+    )
     const params = providerAzurepipelines.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
   })
@@ -132,7 +144,6 @@ describe('Azure Pipelines CI Params', () => {
         BUILD_SOURCEBRANCH: 'refs/heads/main',
         BUILD_SOURCEVERSION: 'testingsha',
         SYSTEM_BUILD_BUILDID: '1',
-        SYSTEM_PULLREQUEST_PULLREQUESTID: '3',
         SYSTEM_TEAMFOUNDATIONSERVERURI: 'https://example.azure.com',
         SYSTEM_TEAMPROJECT: 'testOrg',
       },
@@ -143,7 +154,7 @@ describe('Azure Pipelines CI Params', () => {
       buildURL: 'https://example.azure.comtestOrg/_build/results?buildId=2',
       commit: 'testingsha',
       job: '2',
-      pr: '3',
+      pr: '',
       project: 'testOrg',
       server_uri: 'https://example.azure.com',
       service: 'azure_pipelines',

--- a/test/providers/provider_githubactions.test.ts
+++ b/test/providers/provider_githubactions.test.ts
@@ -92,7 +92,7 @@ describe('GitHub Actions Params', () => {
 
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['show', '--no-patch', '--format="%P"']),
+      spawnSync('git', ['show', '--no-patch', '--format=%P']),
     ).thenReturn({
       stdout: 'testingsha',
     })
@@ -127,7 +127,7 @@ describe('GitHub Actions Params', () => {
 
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['show', '--no-patch', '--format="%P"']),
+      spawnSync('git', ['show', '--no-patch', '--format=%P']),
     ).thenReturn({
       stdout:
         'testingsha123456789012345678901234567890 testingmergecommitsha2345678901234567890',
@@ -166,7 +166,7 @@ describe('GitHub Actions Params', () => {
 
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['show', '--no-patch', '--format="%P"']),
+      spawnSync('git', ['show', '--no-patch', '--format=%P']),
     ).thenReturn({ stdout: 'testsha' })
     const params = providerGitHubactions.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
@@ -199,7 +199,7 @@ describe('GitHub Actions Params', () => {
 
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['show', '--no-patch', '--format="%P"']),
+      spawnSync('git', ['show', '--no-patch', '--format=%P']),
     ).thenReturn({ stdout: '' })
     const params = providerGitHubactions.getServiceParams(inputs)
     expect(params).toMatchObject(expected)


### PR DESCRIPTION
The double quotes get escaped by execFileSync and then are part of the output which makes the Regex fail to match.
Remove them to avoid this.

See https://github.com/boostorg/boost-ci/runs/5394406101?check_suite_focus=true:

```
['verbose'] Handling PR with parent hash(es) '"86f4b7cb20e29080b366ee1593c1135038bda4bf cd099c05fc6d88115e9bbdc0c60b23fb5a0fa952"' of current commit.
['info']     Commit with SHA 9e556cae25da2cb0438a10e81d3f78ddcc7e8510 of PR 125 is not a merge commit
```

Can be reproduced in a shell by running `git show --no-patch --format=\"%P\"`

@drazisil-codecov Finally found this!