### PR TITLE
Release 0.1.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.19](https://github.com/codecov/uploader/compare/v0.1.18...v0.1.19) (2022-03-10)
+
+### Bug Fixes
+
+- add helper arg array method, pass in extra gcov args ([57459e3](https://github.com/codecov/uploader/commit/57459e3b98ea9855da67f7d3c9ac6cd2a8e1c398))
+
 ### [0.1.18](https://github.com/codecov/uploader/compare/v0.1.17...v0.1.18) (2022-03-09)
 
 ### Bug Fixes

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@codecov/uploader",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@codecov/uploader",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "ISC",
       "dependencies": {
         "fast-glob": "3.2.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codecov/uploader",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Codecov Report Uploader",
   "private": true,
   "bin": {


### PR DESCRIPTION
### [0.1.19](https://github.com/codecov/uploader/compare/v0.1.18...v0.1.19) (2022-03-10)

### Bug Fixes

- add helper arg array method, pass in extra gcov args ([57459e3](https://github.com/codecov/uploader/commit/57459e3b98ea9855da67f7d3c9ac6cd2a8e1c398))
