### PR TITLE
chore(release): 0.1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.20](https://github.com/codecov/uploader/compare/v0.1.18...v0.1.20) (2022-03-21)
+
+### Features
+
+- add bitrise provider ([f02e1cf](https://github.com/codecov/uploader/commit/f02e1cf307bf076b01b323f4e01c4a3d7b006c53))
+
+### Bug Fixes
+
+- add helper arg array method, pass in extra gcov args ([57459e3](https://github.com/codecov/uploader/commit/57459e3b98ea9855da67f7d3c9ac6cd2a8e1c398))
+
 ### [0.1.19](https://github.com/codecov/uploader/compare/v0.1.18...v0.1.19) (2022-03-10)
 
 ### Bug Fixes

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@codecov/uploader",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@codecov/uploader",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "ISC",
       "dependencies": {
         "fast-glob": "3.2.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codecov/uploader",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Codecov Report Uploader",
   "private": true,
   "bin": {


### PR DESCRIPTION
## What's Changed
* fix: add helper arg array method, pass in extra gcov args by @michael-codecov in https://github.com/codecov/uploader/pull/658
* Release 0.1.19 by @michael-codecov in https://github.com/codecov/uploader/pull/661
* chore(deps): update node.js to v16.14.1 by @renovate in https://github.com/codecov/uploader/pull/665
* chore(deps): update node.js to v16.14.2 by @renovate in https://github.com/codecov/uploader/pull/668
* feat: add bitrise provider by @thomasrockhu-codecov in https://github.com/codecov/uploader/pull/670


**Full Changelog**: https://github.com/codecov/uploader/compare/v0.1.18...v0.1.20