### PR TITLE
Release 0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.22](https://github.com/codecov/uploader/compare/v0.1.21...v0.1.22) (2022-04-12)
+
+
+### Bug Fixes
+
+* bump package.json ([e5aedde](https://github.com/codecov/uploader/commit/e5aeddefc7f50d2d17ef3e859d021d6d7aca7420))
+
 ### [0.1.21](https://github.com/codecov/uploader/compare/v0.1.20...v0.1.21) (2022-04-11)
 
 ### Bug Fixes

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@codecov/uploader",
-  "version": "0.1.20",
+  "version": "0.1.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@codecov/uploader",
-      "version": "0.1.20",
+      "version": "0.1.22",
       "license": "ISC",
       "dependencies": {
         "fast-glob": "3.2.11",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "husky install",
     "type-check": "tsc --noEmit",
     "type-check:watch": "npm run type-check -- --watch",
-    "release": "npm run lint && standard-version --sign"
+    "release": "standard-version --sign"
   },
   "repository": {
     "type": "git",
@@ -76,7 +76,7 @@
       "prettier --write",
       "eslint --fix"
     ],
-    "**/*.{json,md,yml,yaml,html}": [
+    "**/*.{json,yml,yaml,html}": [
       "prettier --write"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codecov/uploader",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Codecov Report Uploader",
   "private": true,
   "bin": {


### PR DESCRIPTION
## What's Changed
* chore(release): 0.1.21 by @thomasrockhu-codecov in https://github.com/codecov/uploader/pull/706
* fix: bump package.json by @thomasrockhu-codecov in https://github.com/codecov/uploader/pull/708
* Use CI_MERGE_REQUEST_SOURCE_BRANCH_SHA for GitLab CI by @eliatcodecov in https://github.com/codecov/uploader/pull/710

## New Contributors
* @eliatcodecov made their first contribution in https://github.com/codecov/uploader/pull/710

**Full Changelog**: https://github.com/codecov/uploader/compare/v0.1.21...v0.1.22