### PR TITLE
fix: increase spawnsync buffer

### DIFF
--- a/src/helpers/token.ts
+++ b/src/helpers/token.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import yaml from 'js-yaml'
 import path from 'path'
-import { UploaderArgs, UploaderInputs } from '../types'
+import { UploaderInputs } from '../types'
 import { DEFAULT_UPLOAD_HOST } from './constansts'
 import { info, logError, UploadLogger } from './logger'
 import { validateToken } from './validate'
@@ -17,7 +17,7 @@ export function getToken(inputs: UploaderInputs, projectRoot: string): string {
   const options = [
     [args.token, 'arguments'],
     [envs.CODECOV_TOKEN, 'environment variables'],
-    [getTokenFromYaml(projectRoot, args), 'Codecov yaml config'],
+    [getTokenFromYaml(projectRoot), 'Codecov yaml config'],
   ]
 
   for (const [token, source] of options) {
@@ -65,7 +65,6 @@ function yamlParse(input: object | string | number): ICodecovYAML {
 
 export function getTokenFromYaml(
   projectRoot: string,
-  args: UploaderArgs,
 ): string {
   const dirNames = ['', '.github', 'dev']
 

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -1,6 +1,6 @@
 import childprocess from 'child_process'
 
-export const SPAWNPROCESSBUFFERSIZE = 10485760 // 10 MiB
+export const SPAWNPROCESSBUFFERSIZE: number = 10485760 // 10 MiB
 
 export function isProgramInstalled(programName: string): boolean {
   return !childprocess.spawnSync(programName).error

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -1,6 +1,6 @@
 import childprocess from 'child_process'
 
-export const SPAWNPROCESSBUFFERSIZE: number = 10485760 // 10 MiB
+export const SPAWNPROCESSBUFFERSIZE = 1_048_576 * 10 // 10 MiB
 
 export function isProgramInstalled(programName: string): boolean {
   return !childprocess.spawnSync(programName).error

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -1,6 +1,6 @@
 import childprocess from 'child_process'
 
-const SpawnProcessBufferSize = 10485760 // 10MiB
+export const SPAWNPROCESSBUFFERSIZE = 10485760 // 10 MiB
 
 export function isProgramInstalled(programName: string): boolean {
   return !childprocess.spawnSync(programName).error
@@ -13,7 +13,7 @@ export function runExternalProgram(
   const result = childprocess.spawnSync(
     programName,
     optionalArguments,
-    {maxBuffer: SpawnProcessBufferSize}
+    { maxBuffer: SPAWNPROCESSBUFFERSIZE },
   )
   if (result.error) {
     throw new Error(`Error running external program: ${result.error}`)

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -1,5 +1,7 @@
 import childprocess from 'child_process'
 
+const SpawnProcessBufferSize = 10485760 // 10MiB
+
 export function isProgramInstalled(programName: string): boolean {
   return !childprocess.spawnSync(programName).error
 }
@@ -8,7 +10,11 @@ export function runExternalProgram(
   programName: string,
   optionalArguments: string[] = [],
 ): string {
-  const result = childprocess.spawnSync(programName, optionalArguments)
+  const result = childprocess.spawnSync(
+    programName,
+    optionalArguments,
+    {maxBuffer: SpawnProcessBufferSize}
+  )
   if (result.error) {
     throw new Error(`Error running external program: ${result.error}`)
   }

--- a/test/helpers/files.test.ts
+++ b/test/helpers/files.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import childProcess from 'child_process'
 import * as fileHelpers from '../../src/helpers/files'
 import { getBlocklist } from '../../src/helpers/files'
+import { SPAWNPROCESSBUFFERSIZE } from '../../src/helpers/util'
 import mock from 'mock-fs'
 
 describe('File Helpers', () => {
@@ -28,7 +29,7 @@ describe('File Helpers', () => {
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(cwd()).thenReturn({ stdout: 'fish' })
     td.when(
-      spawnSync('git', ['rev-parse', '--show-toplevel']),
+      spawnSync('git', ['rev-parse', '--show-toplevel'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: 'gitRoot' })
 
     expect(fileHelpers.fetchGitRoot()).toBe('gitRoot')

--- a/test/helpers/gcov.test.ts
+++ b/test/helpers/gcov.test.ts
@@ -2,6 +2,7 @@
 import td from 'testdouble'
 import childProcess from 'child_process'
 import { generateGcovCoverageFiles } from '../../src/helpers/gcov'
+import { SPAWNPROCESSBUFFERSIZE } from '../../src/helpers/util'
 
 describe('generateGcovCoverageFiles()', () => {
     afterEach(() => {
@@ -15,7 +16,7 @@ describe('generateGcovCoverageFiles()', () => {
             stdout: 'gcov installed',
             error: null
         })
-        td.when(spawnSync('gcov', td.matchers.contains('test/fixtures/gcov/main.gcno'))).thenReturn({
+        td.when(spawnSync('gcov', td.matchers.contains('test/fixtures/gcov/main.gcno'), { maxBuffer: SPAWNPROCESSBUFFERSIZE })).thenReturn({
             stdout: output,
             error: null
         })
@@ -29,7 +30,7 @@ describe('generateGcovCoverageFiles()', () => {
             stdout: 'gcov installed',
             error: null
         })
-        td.when(spawnSync('gcov', td.matchers.contains('NEWGCOVARG'))).thenReturn({
+        td.when(spawnSync('gcov', td.matchers.contains('NEWGCOVARG'), { maxBuffer: SPAWNPROCESSBUFFERSIZE })).thenReturn({
             stdout: 'Matched',
         })
 

--- a/test/helpers/token.test.ts
+++ b/test/helpers/token.test.ts
@@ -22,36 +22,18 @@ describe('Get tokens', () => {
 
   describe('From yaml', () => {
     it('Returns empty with no yaml file', () => {
-      const args: UploaderArgs = {
-        ...createEmptyArgs(),
-        ...{
-          verbose: 'true',
-        },
-      }
-      expect(tokenHelpers.getTokenFromYaml('.', args)).toBe('')
+      expect(tokenHelpers.getTokenFromYaml('.')).toBe('')
     })
 
     it('Returns the correct token from file', () => {
-      const args: UploaderArgs = {
-        ...createEmptyArgs(),
-        ...{
-          verbose: 'true',
-        },
-      }
-      expect(tokenHelpers.getTokenFromYaml(fixturesDir, args)).toBe('faketoken')
+      expect(tokenHelpers.getTokenFromYaml(fixturesDir)).toBe('faketoken')
     })
 
     it('Returns deprecation error from codecov_token', () => {
-      const args: UploaderArgs = {
-        ...createEmptyArgs(),
-        ...{
-          verbose: 'true',
-        },
-      }
       jest.spyOn(console, 'error').mockImplementation(() => {
         // Intentionally empty
       })
-      expect(tokenHelpers.getTokenFromYaml(invalidFixturesDir, args)).toBe('')
+      expect(tokenHelpers.getTokenFromYaml(invalidFixturesDir)).toBe('')
 
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining("'codecov_token' is a deprecated field"),

--- a/test/helpers/util.test.ts
+++ b/test/helpers/util.test.ts
@@ -1,6 +1,10 @@
 import childProcess from 'child_process'
 import td from 'testdouble'
-import { isProgramInstalled , runExternalProgram} from '../../src/helpers/util'
+import {
+    isProgramInstalled,
+    runExternalProgram,
+    SPAWNPROCESSBUFFERSIZE,
+} from '../../src/helpers/util'
 
 describe('isProgramInstalled()', () => {
     afterEach(() => {
@@ -24,7 +28,7 @@ describe('runExternalProgram()', () => {
 
     it('should throw an error when program is not found', () => {
         const spawnSync = td.replace(childProcess, 'spawnSync')
-        td.when(spawnSync('ls', ['-geewhiz'])).thenReturn({
+        td.when(spawnSync('ls', ['-geewhiz'], { maxBuffer: SPAWNPROCESSBUFFERSIZE })).thenReturn({
           error: 'Huh?',
         })
         expect(() => runExternalProgram('ls', ['-geewhiz'])).toThrowError(/Huh\?/)
@@ -33,7 +37,7 @@ describe('runExternalProgram()', () => {
 
     it('should return stdout on success', () => {
         const spawnSync = td.replace(childProcess, 'spawnSync')
-        td.when(spawnSync('ls', ['-geewhiz'])).thenReturn({
+        td.when(spawnSync('ls', ['-geewhiz'], { maxBuffer: SPAWNPROCESSBUFFERSIZE })).thenReturn({
           stdout: 'I am output',
         })
         expect(runExternalProgram('ls', ['-geewhiz'])).toEqual("I am output")
@@ -42,13 +46,13 @@ describe('runExternalProgram()', () => {
 
     it('should return a trimmed string with no newlines', () => {
         const spawnSync = td.replace(childProcess, 'spawnSync')
-        td.when(spawnSync('ls', ['-geewhiz'])).thenReturn({
+        td.when(spawnSync('ls', ['-geewhiz'], { maxBuffer: SPAWNPROCESSBUFFERSIZE })).thenReturn({
           stdout: `
-          
-          
+
+
           I am output
-          
-          
+
+
           `,
         })
         expect(runExternalProgram('ls', ['-geewhiz'])).toEqual("I am output")

--- a/test/providers/provider_azurepipelines.test.ts
+++ b/test/providers/provider_azurepipelines.test.ts
@@ -2,6 +2,7 @@ import td from 'testdouble'
 import childProcess from 'child_process'
 
 import * as providerAzurepipelines from '../../src/ci_providers//provider_azurepipelines'
+import { SPAWNPROCESSBUFFERSIZE } from '../../src/helpers/util'
 import { IServiceParams, UploaderInputs } from '../../src/types'
 import { createEmptyArgs } from '../test_helpers'
 
@@ -53,7 +54,7 @@ describe('Azure Pipelines CI Params', () => {
     }
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['config', '--get', 'remote.origin.url']),
+      spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: '' })
 
     const params = providerAzurepipelines.getServiceParams(inputs)
@@ -162,7 +163,7 @@ describe('Azure Pipelines CI Params', () => {
 
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['config', '--get', 'remote.origin.url']),
+      spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: 'https://github.com/testOrg/testRepo.git' })
     const params = providerAzurepipelines.getServiceParams(inputs)
     expect(params).toMatchObject(expected)

--- a/test/providers/provider_bitbucket.test.ts
+++ b/test/providers/provider_bitbucket.test.ts
@@ -1,6 +1,7 @@
 import childProcess from 'child_process'
 import td from 'testdouble'
 import * as providerBitbucket from '../../src/ci_providers//provider_bitbucket'
+import { SPAWNPROCESSBUFFERSIZE } from '../../src/helpers/util'
 import { IServiceParams, UploaderInputs } from '../../src/types'
 import { createEmptyArgs } from '../test_helpers'
 
@@ -132,7 +133,7 @@ describe('Bitbucket Params', () => {
     }
 
     const execFileSync = td.replace(childProcess, 'spawnSync')
-    td.when(execFileSync('git', ['rev-parse', 'testingsha12'])).thenReturn(
+    td.when(execFileSync('git', ['rev-parse', 'testingsha12'], { maxBuffer: SPAWNPROCESSBUFFERSIZE })).thenReturn(
       { stdout: 'newtestsha'},
     )
     const params = providerBitbucket.getServiceParams(inputs)

--- a/test/providers/provider_bitrise.test.ts
+++ b/test/providers/provider_bitrise.test.ts
@@ -1,5 +1,6 @@
 import td from 'testdouble'
 import childProcess from 'child_process'
+import { SPAWNPROCESSBUFFERSIZE } from '../../src/helpers/util'
 import { IServiceParams, UploaderInputs } from '../../src/types'
 import { createEmptyArgs } from '../test_helpers'
 
@@ -65,7 +66,7 @@ describe('Bitrise Params', () => {
     }
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['config', '--get', 'remote.origin.url']),
+      spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: '' })
 
     const params = providerBitrise.getServiceParams(inputs)
@@ -97,7 +98,7 @@ describe('Bitrise Params', () => {
     }
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['config', '--get', 'remote.origin.url']),
+      spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: 'https://github.com/testOrg/testRepo.git' })
     const params = providerBitrise.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
@@ -128,7 +129,7 @@ describe('Bitrise Params', () => {
     }
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['config', '--get', 'remote.origin.url']),
+      spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: 'https://github.com/testOrg/testRepo.git' })
     const params = providerBitrise.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
@@ -169,7 +170,7 @@ describe('Bitrise Params', () => {
     }
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['config', '--get', 'remote.origin.url']),
+      spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: 'https://github.com/testOrg/testRepo.git' })
     const params = providerBitrise.getServiceParams(inputs)
     expect(params).toMatchObject(expected)

--- a/test/providers/provider_githubactions.test.ts
+++ b/test/providers/provider_githubactions.test.ts
@@ -2,6 +2,7 @@ import td from 'testdouble'
 import childProcess from 'child_process'
 
 import * as providerGitHubactions from '../../src/ci_providers//provider_githubactions'
+import { SPAWNPROCESSBUFFERSIZE } from '../../src/helpers/util'
 import { IServiceParams, UploaderInputs } from '../../src/types'
 import { createEmptyArgs } from '../test_helpers'
 
@@ -92,7 +93,7 @@ describe('GitHub Actions Params', () => {
 
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['show', '--no-patch', '--format=%P']),
+      spawnSync('git', ['show', '--no-patch', '--format=%P'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({
       stdout: 'testingsha',
     })
@@ -127,7 +128,7 @@ describe('GitHub Actions Params', () => {
 
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['show', '--no-patch', '--format=%P']),
+      spawnSync('git', ['show', '--no-patch', '--format=%P'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({
       stdout:
         'testingsha123456789012345678901234567890 testingmergecommitsha2345678901234567890',
@@ -166,7 +167,7 @@ describe('GitHub Actions Params', () => {
 
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['show', '--no-patch', '--format=%P']),
+      spawnSync('git', ['show', '--no-patch', '--format=%P'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: 'testsha' })
     const params = providerGitHubactions.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
@@ -199,7 +200,7 @@ describe('GitHub Actions Params', () => {
 
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['show', '--no-patch', '--format=%P']),
+      spawnSync('git', ['show', '--no-patch', '--format=%P'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: '' })
     const params = providerGitHubactions.getServiceParams(inputs)
     expect(params).toMatchObject(expected)

--- a/test/providers/provider_gitlabci.test.ts
+++ b/test/providers/provider_gitlabci.test.ts
@@ -2,6 +2,7 @@ import td from 'testdouble'
 import childProcess from 'child_process'
 
 import * as providerGitLabci from '../../src/ci_providers//provider_gitlabci'
+import { SPAWNPROCESSBUFFERSIZE } from '../../src/helpers/util'
 import { IServiceParams, UploaderInputs } from '../../src/types'
 import { createEmptyArgs } from '../test_helpers'
 
@@ -51,7 +52,7 @@ describe('GitLabCI Params', () => {
     }
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['config', '--get', 'remote.origin.url']),
+      spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: '' })
     const params = providerGitLabci.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
@@ -135,7 +136,7 @@ describe('GitLabCI Params', () => {
       inputs.environment.CI_BUILD_REPO = ''
       const spawnSync = td.replace(childProcess, 'spawnSync')
       td.when(
-        spawnSync('git', ['config', '--get', 'remote.origin.url']),
+        spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
       ).thenReturn({ stdout: 'https://gitlab.com/testOrg/testRepo.git' })
 
       const params = providerGitLabci.getServiceParams(inputs)
@@ -146,7 +147,7 @@ describe('GitLabCI Params', () => {
       inputs.environment.CI_BUILD_REPO = ''
       const spawnSync = td.replace(childProcess, 'spawnSync')
       td.when(
-        spawnSync('git', ['config', '--get', 'remote.origin.url']),
+        spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
       ).thenReturn({ stdout: 'git@gitlab.com:/' })
 
       const params = providerGitLabci.getServiceParams(inputs)
@@ -157,7 +158,7 @@ describe('GitLabCI Params', () => {
       inputs.environment.CI_BUILD_REPO = ''
       const spawnSync = td.replace(childProcess, 'spawnSync')
       td.when(
-        spawnSync('git', ['config', '--get', 'remote.origin.url']),
+        spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
       ).thenReturn({ stdout: '' })
 
       const params = providerGitLabci.getServiceParams(inputs)

--- a/test/providers/provider_herokuci.test.ts
+++ b/test/providers/provider_herokuci.test.ts
@@ -1,5 +1,6 @@
 import td from 'testdouble'
 import childProcess from 'child_process'
+import { SPAWNPROCESSBUFFERSIZE } from '../../src/helpers/util'
 import { IServiceParams, UploaderInputs } from '../../src/types'
 import { createEmptyArgs } from '../test_helpers'
 
@@ -51,7 +52,7 @@ describe('HerokuCI Params', () => {
     }
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['config', '--get', 'remote.origin.url']),
+      spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: '' })
     const params = providerHerokuci.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
@@ -80,7 +81,7 @@ describe('HerokuCI Params', () => {
     }
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['config', '--get', 'remote.origin.url']),
+      spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: 'https://github.com/testOrg/testRepo.git' })
     const params = providerHerokuci.getServiceParams(inputs)
     expect(params).toMatchObject(expected)

--- a/test/providers/provider_jenkinsci.test.ts
+++ b/test/providers/provider_jenkinsci.test.ts
@@ -2,6 +2,7 @@ import td from 'testdouble'
 import childProcess from 'child_process'
 
 import * as providerJenkinsci from '../../src/ci_providers//provider_jenkinsci'
+import { SPAWNPROCESSBUFFERSIZE } from '../../src/helpers/util'
 import { IServiceParams, UploaderInputs } from '../../src/types'
 import { createEmptyArgs } from '../test_helpers'
 
@@ -60,7 +61,7 @@ describe('Jenkins CI Params', () => {
     }
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['config', '--get', 'remote.origin.url']),
+      spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: '' })
     const params = providerJenkinsci.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
@@ -80,7 +81,7 @@ describe('Jenkins CI Params', () => {
     }
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['config', '--get', 'remote.origin.url']),
+      spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: 'https://github.com/testOrg/testRepo.git' })
 
     const params = providerJenkinsci.getServiceParams(inputs)

--- a/test/providers/provider_local.test.ts
+++ b/test/providers/provider_local.test.ts
@@ -2,6 +2,7 @@ import td from 'testdouble'
 import childProcess from 'child_process'
 
 import * as providerLocal from '../../src/ci_providers//provider_local'
+import { SPAWNPROCESSBUFFERSIZE } from '../../src/helpers/util'
 import { IServiceParams, UploaderInputs } from '../../src/types'
 import { createEmptyArgs } from '../test_helpers'
 
@@ -91,7 +92,7 @@ describe('Local Params', () => {
       providerLocal.getServiceParams(inputs)
     }).toThrow()
 
-    td.when(spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'])).thenReturn(
+    td.when(spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { maxBuffer: SPAWNPROCESSBUFFERSIZE })).thenReturn(
       {
         stdout: 'main',
       },
@@ -100,7 +101,7 @@ describe('Local Params', () => {
       providerLocal.getServiceParams(inputs)
     }).toThrow()
 
-    td.when(spawnSync('git', ['rev-parse', 'HEAD'])).thenReturn({
+    td.when(spawnSync('git', ['rev-parse', 'HEAD'], { maxBuffer: SPAWNPROCESSBUFFERSIZE })).thenReturn({
       stdout: 'testSHA',
     })
     expect(() => {
@@ -117,16 +118,16 @@ describe('Local Params', () => {
     it('can get the slug from a git url', () => {
       const spawnSync = td.replace(childProcess, 'spawnSync')
       td.when(
-        spawnSync('git', ['config', '--get', 'remote.origin.url']),
+        spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
       ).thenReturn({
         stdout: 'git@github.com:testOrg/testRepo.git',
       })
       td.when(
-        spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD']),
+        spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
       ).thenReturn({
         stdout: 'main',
       })
-      td.when(spawnSync('git', ['rev-parse', 'HEAD'])).thenReturn({
+      td.when(spawnSync('git', ['rev-parse', 'HEAD'], { maxBuffer: SPAWNPROCESSBUFFERSIZE })).thenReturn({
         stdout: 'testSHA',
       })
       expect(providerLocal.getServiceParams(inputs).slug).toBe(
@@ -137,16 +138,16 @@ describe('Local Params', () => {
     it('can get the slug from an http(s) url', () => {
       const spawnSync = td.replace(childProcess, 'spawnSync')
       td.when(
-        spawnSync('git', ['config', '--get', 'remote.origin.url']),
+        spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
       ).thenReturn({
         stdout: 'notaurl',
       })
       td.when(
-        spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD']),
+        spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
       ).thenReturn({
         stdout: 'main',
       })
-      td.when(spawnSync('git', ['rev-parse', 'HEAD'])).thenReturn({
+      td.when(spawnSync('git', ['rev-parse', 'HEAD'], { maxBuffer: SPAWNPROCESSBUFFERSIZE })).thenReturn({
         stdout: 'testSHA',
       })
       expect(() => {
@@ -157,16 +158,16 @@ describe('Local Params', () => {
     it('errors on a malformed slug', () => {
       const spawnSync = td.replace(childProcess, 'spawnSync')
       td.when(
-        spawnSync('git', ['config', '--get', 'remote.origin.url']),
+        spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
       ).thenReturn({
         stdout: 'http://github.com/testOrg/testRepo.git',
       })
       td.when(
-        spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD']),
+        spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
       ).thenReturn({
         stdout: 'main',
       })
-      td.when(spawnSync('git', ['rev-parse', 'HEAD'])).thenReturn({
+      td.when(spawnSync('git', ['rev-parse', 'HEAD'], { maxBuffer: SPAWNPROCESSBUFFERSIZE })).thenReturn({
         stdout: 'testSHA',
       })
       expect(providerLocal.getServiceParams(inputs).slug).toBe(

--- a/test/providers/provider_teamcity.test.ts
+++ b/test/providers/provider_teamcity.test.ts
@@ -2,6 +2,7 @@ import td from 'testdouble'
 import childProcess from 'child_process'
 
 import * as providerTeamCity from '../../src/ci_providers/provider_teamcity'
+import { SPAWNPROCESSBUFFERSIZE } from '../../src/helpers/util'
 import { IServiceParams, UploaderInputs } from '../../src/types'
 import { createEmptyArgs } from '../test_helpers'
 
@@ -56,7 +57,7 @@ describe('TeamCity Params', () => {
     }
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['config', '--get', 'remote.origin.url']),
+      spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: '' })
     const params = providerTeamCity.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
@@ -85,7 +86,7 @@ describe('TeamCity Params', () => {
     }
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['config', '--get', 'remote.origin.url']),
+      spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: 'https://github.com/testOrg/testRepo.git' })
     const params = providerTeamCity.getServiceParams(inputs)
     expect(params).toMatchObject(expected)
@@ -113,7 +114,7 @@ describe('TeamCity Params', () => {
     }
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(
-      spawnSync('git', ['config', '--get', 'remote.origin.url']),
+      spawnSync('git', ['config', '--get', 'remote.origin.url'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: '' })
     const expected: IServiceParams = {
       branch: 'branch',


### PR DESCRIPTION
Fixes the issue [here](https://github.com/RemedyIT/taox11/runs/5996166946?check_suite_focus=true) where running `gcov` exceeds the buffer size. Also removes unused argument from `token.ts`