### PR TITLE
fix: store upload file contents on a Buffer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ export async function main(
 
   // #endregion
   // #region == Step 4: get network
-  let uploadFile = ''
+  const uploadFileChunks: Buffer[] = []
 
   if (!args.feature || args.feature.split(',').includes('network') === false) {
     UploadLogger.verbose('Start of network processing...')
@@ -149,7 +149,8 @@ export async function main(
       throw new Error(`Error getting file listing: ${error}`)
     }
 
-    uploadFile = uploadFile.concat(fileListing).concat(MARKER_NETWORK_END)
+    uploadFileChunks.push(Buffer.from(fileListing))
+    uploadFileChunks.push(Buffer.from(MARKER_NETWORK_END))
   }
 
   // #endregion
@@ -269,10 +270,9 @@ export async function main(
       continue
     }
 
-    uploadFile = uploadFile
-      .concat(fileHeader(coverageFile))
-      .concat(fileContents)
-      .concat(MARKER_FILE_END)
+    uploadFileChunks.push(Buffer.from(fileHeader(coverageFile)))
+    uploadFileChunks.push(Buffer.from(fileContents))
+    uploadFileChunks.push(Buffer.from(MARKER_FILE_END))
     coverageFileAdded = true
   }
   if (!coverageFileAdded) {
@@ -294,9 +294,11 @@ export async function main(
       .filter(Boolean)
       .map(evar => `${evar}=${process.env[evar] || ''}\n`)
       .join('')
-    uploadFile = uploadFile.concat(vars).concat(MARKER_ENV_END)
+    uploadFileChunks.push(Buffer.from(vars))
+    uploadFileChunks.push(Buffer.from(MARKER_ENV_END))
   }
 
+  const uploadFile = Buffer.concat(uploadFileChunks)
   const gzippedFile = zlib.gzipSync(uploadFile)
 
   // #endregion
@@ -323,7 +325,7 @@ export async function main(
   const query = webHelpers.generateQuery(buildParams)
 
   if (args.dryRun) {
-    dryRun(uploadHost, token, query, uploadFile, args.source || '')
+    dryRun(uploadHost, token, query, uploadFile.toString(), args.source || '')
     return
   }
 


### PR DESCRIPTION
Workaround for #745. Instead of keeping the contents into a `string`, keep them into a `Buffer` instead. All the APIs seemed to already accept buffers.

`Buffer.from()` does [copy the underlying data](https://nodejs.org/api/buffer.html#bufferfrom-bufferalloc-and-bufferallocunsafe), but that should be ok since the strings we are copying are short lived

## tests
`npm run test` passes

following the repro steps on #745:

**before**:
```
[2022-04-30T23:08:35.567Z] ['info'] Processing /Users/gabriel.russo/uploader/giant_files/4.dat...
[2022-04-30T23:08:35.660Z] ['info'] Processing /Users/gabriel.russo/uploader/giant_files/5.dat...
[2022-04-30T23:08:35.748Z] ['info'] Processing /Users/gabriel.russo/uploader/giant_files/6.dat...
[2022-04-30T23:08:35.838Z] ['error'] There was an error running the uploader: Invalid string length
```

**after**:
```
...
[2022-04-30T23:04:28.887Z] ['info'] Processing /Users/gabriel.russo/uploader/giant_files/7.dat...
[2022-04-30T23:04:29.095Z] ['info'] Processing /Users/gabriel.russo/uploader/giant_files/8.dat...
[2022-04-30T23:04:29.292Z] ['info'] Processing /Users/gabriel.russo/uploader/giant_files/9.dat...
[2022-04-30T23:04:33.259Z] ['info'] Detected Local as the CI provider.
[2022-04-30T23:04:33.334Z] ['info'] Pinging Codecov: https://codecov.io/upload/v4?package=uploader-0.2.0&token=*******&branch=main&build=&build_url=&commit=241e5bd3d3fab8bd76eb32270b400e571e73c5f8&job=&pr=&service=&slug=gabrielrussoc%2Fuploader&name=&tag=&flags=&parent=
...
```