### PR TITLE
Jenkins: branch/commit handling for multibranch pipelines

### DIFF
--- a/src/ci_providers/provider_jenkinsci.ts
+++ b/src/ci_providers/provider_jenkinsci.ts
@@ -20,6 +20,7 @@ function _getBranch(inputs: UploaderInputs): string {
   return (
     args.branch ||
     envs.ghprbSourceBranch ||
+    envs.CHANGE_BRANCH ||
     envs.GIT_BRANCH ||
     envs.BRANCH_NAME ||
     ''
@@ -45,6 +46,9 @@ export function getServiceName(): string {
 
 function _getSHA(inputs: UploaderInputs): string {
   const { args, environment: envs } = inputs
+  // Note that the value of GIT_COMMIT may not be accurate if Jenkins
+  // is merging `master` in to the working branch first. In these cases
+  // there is no envvar representing the actual submitted commit
   return args.sha || envs.ghprbActualCommit || envs.GIT_COMMIT || ''
 }
 


### PR DESCRIPTION
When using multibranch pipelines, Jenkins will create a new branch for pull requests named "PR-X" where X is the ID. This means that submitting the branch name to Codecov will not represent real branches from the project.

It is also the case that in multibranch projects, Jenkins may merge `master` into the working branch. In the event this creates a merge commit the `GIT_COMMIT` envvar will point to this rather than the commit being tested (and thus the given commit hash will be irrelevant when posting to external services). This PR does not fix that but adds a note in the code to assist future people encountering this issue.