### PR TITLE
Disable `standards-coverage-comparison`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,12 +478,12 @@ workflows:
 
   'Build and Test':
     jobs:
-      - standards-coverage-comparison:
-          context:
-            - 'DockerHub Push Context'
-            - 'Github Checkout'
-          requires:
-            - build-alpine
+#       - standards-coverage-comparison:
+#           context:
+#             - 'DockerHub Push Context'
+#             - 'Github Checkout'
+#           requires:
+#             - build-alpine
       - build-linux-and-osx
       - build-alpine:
           requires:


### PR DESCRIPTION
Autotest has been failing for quite some time. While the failed CI runs do not have material impact on the project, the status checks they send to GitHub show up next to each commit. The failed indicator is misleading and a cause of information saturation.