### PR TITLE
fix: parse both versions of ssh urls for remotes

### DIFF
--- a/src/helpers/git.ts
+++ b/src/helpers/git.ts
@@ -11,7 +11,7 @@ export function parseSlug(slug: string): string {
     // Type is http(s) or ssh
     const phaseOne = slug.split('//')[1]?.replace('.git', '') || ''
     const phaseTwo = phaseOne?.split('/') || ''
-    const cleanSlug = `${phaseTwo[1]}/${phaseTwo[2]}`
+    const cleanSlug = phaseTwo.length > 2 ? `${phaseTwo[1]}/${phaseTwo[2]}` : ''
     return cleanSlug
   } else if (slug.match('@')) {
     // Type is git

--- a/src/helpers/git.ts
+++ b/src/helpers/git.ts
@@ -7,8 +7,8 @@ export function parseSlug(slug: string): string {
     return ''
   }
 
-  if (slug.match('http')) {
-    // Type is http(s)
+  if (slug.match('http:') || slug.match('https:') || slug.match('ssh:')) {
+    // Type is http(s) or ssh
     const phaseOne = slug.split('//')[1]?.replace('.git', '') || ''
     const phaseTwo = phaseOne?.split('/') || ''
     const cleanSlug = `${phaseTwo[1]}/${phaseTwo[2]}`

--- a/test/helpers/git.test.ts
+++ b/test/helpers/git.test.ts
@@ -20,4 +20,18 @@ describe('Git Helper', () => {
     const remoteAddr = 'git@github.com:codecov/uploader.git'
     expect(parseSlug(remoteAddr)).toBe('codecov/uploader')
   })
+
+  it('doesn\'t error with malformed http urls', () => {
+    const remoteAddr = 'http://github.com/codecov'
+    expect(parseSlug(remoteAddr)).toBe('')
+  })
+
+  it('doesn\'t error with malformed short ssh urls', () => {
+    const remoteAddr = 'git@github.com/abcd'
+    expect(parseSlug(remoteAddr)).toBe('')
+  })
+
+  it('errors with unexpected addr', () => {
+    expect(() => { parseSlug('test non remoteAddr') }).toThrowError(/Unable to parse slug URL/)
+  })
 })

--- a/test/helpers/git.test.ts
+++ b/test/helpers/git.test.ts
@@ -1,0 +1,23 @@
+import { parseSlug } from '../../src/helpers/git'
+
+describe('Git Helper', () => {
+  it('should be able to parse http urls', () => {
+    const remoteAddr = 'http://github.com/codecov/uploader.git'
+    expect(parseSlug(remoteAddr)).toBe('codecov/uploader')
+  })
+
+  it('should be able to parse https urls', () => {
+    const remoteAddr = 'https://github.com/codecov/uploader.git'
+    expect(parseSlug(remoteAddr)).toBe('codecov/uploader')
+  })
+
+  it('should be able to parse ssh urls', () => {
+    const remoteAddr = 'ssh://git@github.com/codecov/uploader.git'
+    expect(parseSlug(remoteAddr)).toBe('codecov/uploader')
+  })
+
+  it('should be able to parse short form ssh urls', () => {
+    const remoteAddr = 'git@github.com:codecov/uploader.git'
+    expect(parseSlug(remoteAddr)).toBe('codecov/uploader')
+  })
+})


### PR DESCRIPTION
Fixes #792
Signed-off-by: Vihang Mehta <vihang@pixielabs.ai>