### PR TITLE
(DO NOT MERGE) fix: require non-empty patterns

### DIFF
--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -1,4 +1,4 @@
-import { default as assert } from 'assert/strict'
+import * as assert from 'assert'
 import { spawnSync } from 'child_process'
 import glob from 'fast-glob'
 import fs from 'fs'

--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert/strict'
+import { default as assert } from 'assert/strict'
 import { spawnSync } from 'child_process'
 import glob from 'fast-glob'
 import fs from 'fs'

--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -1,3 +1,4 @@
+import * as assert from 'assert/strict'
 import { spawnSync } from 'child_process'
 import glob from 'fast-glob'
 import fs from 'fs'
@@ -199,9 +200,16 @@ export async function getCoverageFiles(
   return glob(coverageFilePatterns.map((pattern: string) => {
     const parts = []
 
+    try {
+      assert.notStrictEqual(pattern, EMPTY_STRING)
+      assert.notStrictEqual(pattern, '!')
+    } catch {
+      return EMPTY_STRING // Will cause `glob` to throw an error
+    }
+
     if (isNegated(pattern)) {
       parts.push('!')
-      parts.push(globstar(pattern.substr(1)))
+      parts.push(globstar(pattern.substring(1)))
     } else {
       parts.push(globstar(pattern))
     }

--- a/test/helpers/files.test.ts
+++ b/test/helpers/files.test.ts
@@ -238,6 +238,22 @@ describe('File Helpers', () => {
         await fileHelpers.getCoverageFiles('.', ['coverage.txt', '!test/fixtures/other']),
       ).toStrictEqual(['test/fixtures/coverage.txt'])
     })
+    it('throws an error if passed an empty pattern', async () => {
+      const EMPTY_STRING = '' as const
+
+      await expect(
+        fileHelpers.getCoverageFiles('.', [
+          EMPTY_STRING,
+        ]),
+      ).rejects.toThrowError();
+    })
+    it('throws an error if passed an empty negated pattern', async () => {
+      await expect(
+        fileHelpers.getCoverageFiles('.', [
+          '!', // Empty
+        ]),
+      ).rejects.toThrowError();
+    })
     describe('coverage file patterns', () => {
       it('contains `jacoco*.xml`', () => {
         expect(fileHelpers.coverageFilePatterns()).toContain('jacoco*.xml')


### PR DESCRIPTION
Fixes #677 