### PR TITLE
chore: ignore output directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,8 +61,8 @@ typings/
 .next
 
 # pkg output
-out/*
-dist/*
+out/
+dist/
 
 codecov
 codecov-macos


### PR DESCRIPTION
This PR updates the ignore rules for output directories to, rather than ignore the files within them _specifically_ by rule, ignore the output directories themselves. This has the benefit of providing a better IDE experience wherein the folder (rather than just the contents _within_ the folder) will appear ignored.