### PR TITLE
refactor: exit on invalid slug

### DIFF
--- a/src/helpers/checkSlug.ts
+++ b/src/helpers/checkSlug.ts
@@ -1,0 +1,6 @@
+export function checkSlug(slug: string | undefined): boolean {
+  if (slug !== '' && !slug?.match(/\//)) {
+    return false
+  }
+  return true
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import zlib from 'zlib'
 import { version } from '../package.json'
 import { detectProvider } from './helpers/provider'
 import * as webHelpers from './helpers/web'
-import { info, logError, UploadLogger } from './helpers/logger'
+import { info, UploadLogger } from './helpers/logger'
 import { getToken } from './helpers/token'
 import {
   cleanCoverageFilePaths,

--- a/src/index.ts
+++ b/src/index.ts
@@ -328,8 +328,7 @@ export async function main(
 
   const validSlug =  checkSlug(buildParams.slug)
   if (!validSlug) {
-    logError(`Slug must follow the format of "<owner>/<repo>" or be blank. We detected "${buildParams.slug}"`);
-    process.exit(args.nonZero ? -1 : 0)
+    throw new Error(`Slug must follow the format of "<owner>/<repo>" or be blank. We detected "${buildParams.slug}"`)
   }
 
   const query = webHelpers.generateQuery(buildParams)

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { generateCoveragePyFile } from './helpers/coveragepy'
 import { generateGcovCoverageFiles } from './helpers/gcov'
 import { generateXcodeCoverageFiles } from './helpers/xcode'
 import { argAsArray } from './helpers/util'
+import { checkSlug } from './helpers/checkSlug'
 
 /**
  *
@@ -325,8 +326,10 @@ export async function main(
     UploadLogger.verbose(`${parameter}`)
   }
 
-  if (buildParams.slug !== '' && !buildParams.slug?.match(/\//)) {
-    logError(`Slug must follow the format of "<owner>/<repo>" or be blank. We detected "${buildParams.slug}"`)
+  const validSlug =  checkSlug(buildParams.slug)
+  if (!validSlug) {
+    logError(`Slug must follow the format of "<owner>/<repo>" or be blank. We detected "${buildParams.slug}"`);
+    process.exit(args.nonZero ? -1 : 0)
   }
 
   const query = webHelpers.generateQuery(buildParams)

--- a/test/helpers/checkSlug.test.ts
+++ b/test/helpers/checkSlug.test.ts
@@ -1,0 +1,39 @@
+import { checkSlug } from "../../src/helpers/checkSlug";
+
+describe('checkSlug()', () => {
+    it('should return true for a slug with a forward slash', () => {
+        // arrange
+        const inputSlug = "testOrg/testRepo"
+        const expectedResult = true
+
+        // act
+        const result = checkSlug(inputSlug)
+
+        // assert
+        expect(result).toEqual(expectedResult)
+    })
+
+    it('should return false for a slug without a forward slash', () => {
+        // arrange
+        const inputSlug = 'testRepo'
+        const expectedResult = false
+
+        // act
+        const result = checkSlug(inputSlug)
+
+        // assert
+        expect(result).toEqual(expectedResult)
+    })
+
+    it('should return false for a slug that is "undefined"', () => {
+        // arrange
+        const inputSlug = undefined
+        const expectedResult = false
+
+        // act
+        const result = checkSlug(inputSlug)
+
+        // assert
+        expect(result).toEqual(expectedResult)
+    })
+})


### PR DESCRIPTION
If slug is missing a forward slash, or "undefined", log error and exit