### PR TITLE
fix: suppress errors during glob for files

### DIFF
--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -211,6 +211,7 @@ export async function getCoverageFiles(
     cwd: projectRoot,
     dot: true,
     ignore: getBlocklist(),
+    suppressErrors: true,
   })
 }
 
@@ -249,6 +250,7 @@ export function getAllFiles(
       .sync(['**/*', '**/.[!.]*'], {
         cwd: dirPath,
         ignore: manualBlocklist().map(globstar),
+        suppressErrors: true,
       })
   } else {
     files = stdout.split(/[\r\n]+/)


### PR DESCRIPTION
If a directory or file exists, but Codecov does not have read access, `glob` will return a 

```
There was an error running the uploader: EACCES: permission denied, scandir <directory>
```
error. This should be avoided, and uploading should continue as expected

Related: https://community.codecov.com/t/cant-make-ignore-option-work-for-directory-with-strict-permissions/3814