### PR TITLE
chore(release): 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.3.5](https://github.com/codecov/uploader/compare/v0.3.3...v0.3.5) (2023-02-16)
+
+
+### Bug Fixes
+
+* **files:** exclude .go and .marker files ([#935](https://github.com/codecov/uploader/issues/935)) ([43924aa](https://github.com/codecov/uploader/commit/43924aa254b87f62bf07feba47d8c17a766a6d21))
+
 ### [0.3.4](https://github.com/codecov/uploader/compare/v0.3.2...v0.3.4) (2023-02-15)
 
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@codecov/uploader",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@codecov/uploader",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "ISC",
       "dependencies": {
         "fast-glob": "3.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codecov/uploader",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Codecov Report Uploader",
   "private": true,
   "bin": {


### PR DESCRIPTION
## What's Changed
* chore(release): 0.3.4 by @thomasrockhu-codecov in https://github.com/codecov/uploader/pull/934
* fix(files): exclude .go and .marker files by @drazisil-codecov in https://github.com/codecov/uploader/pull/935


**Full Changelog**: https://github.com/codecov/uploader/compare/v0.3.4...v0.3.5