### PR TITLE
Update fetchGitRoot to not halt execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Codecov Uploader
+# Codecov Uploader 
 
 [![CircleCI](https://circleci.com/gh/codecov/uploader.svg?style=shield&circle-token=def755bf76a1d8c36436c3115530c7eac7fa30e0)](https://circleci.com/gh/codecov/uploader) [![codecov](https://codecov.io/gh/codecov/uploader/branch/master/graph/badge.svg?token=X1gImxfIya)](https://codecov.io/gh/codecov/uploader)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fcodecov%2Fuploader.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fcodecov%2Fuploader?ref=badge_shield) [![Total alerts](https://img.shields.io/lgtm/alerts/g/codecov/uploader.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/codecov/uploader/alerts/)

--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -220,11 +220,13 @@ export async function getCoverageFiles(
 }
 
 export function fetchGitRoot(): string {
+  const currentWorkingDirectory = process.cwd() 
   try {
-    return (
-      runExternalProgram('git', ['rev-parse', '--show-toplevel'])) || process.cwd()
+    const gitRoot = runExternalProgram('git', ['rev-parse', '--show-toplevel'])
+    return (gitRoot != "" ? gitRoot : currentWorkingDirectory)
   } catch (error) {
-    throw new Error(`Error fetching git root. Please try using the -R flag. ${error}`)
+    UploadLogger.verbose(`Error fetching git root. Defaulting to ${currentWorkingDirectory}. Please try using the -R flag. ${error}`)
+    return currentWorkingDirectory
   }
 }
 

--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 import { readFile } from 'fs/promises'
 import { posix as path } from 'path'
 import { UploaderArgs } from '../types'
-import { logError, UploadLogger } from './logger'
+import { info, logError, UploadLogger } from './logger'
 import { runExternalProgram } from './util'
 import micromatch from "../vendor/micromatch/index.js";
 import { SPAWNPROCESSBUFFERSIZE } from './constants'
@@ -225,7 +225,7 @@ export function fetchGitRoot(): string {
     const gitRoot = runExternalProgram('git', ['rev-parse', '--show-toplevel'])
     return (gitRoot != "" ? gitRoot : currentWorkingDirectory)
   } catch (error) {
-    UploadLogger.verbose(`Error fetching git root. Defaulting to ${currentWorkingDirectory}. Please try using the -R flag. ${error}`)
+    info(`Error fetching git root. Defaulting to ${currentWorkingDirectory}. Please try using the -R flag. ${error}`)
     return currentWorkingDirectory
   }
 }

--- a/test/helpers/files.test.ts
+++ b/test/helpers/files.test.ts
@@ -38,8 +38,8 @@ describe('File Helpers', () => {
   it('returns cwd when it cannot fetch the git root', () => {
     const cwd = td.replace(process, 'cwd')
     td.replace(childProcess, 'spawnSync')
-    td.when(cwd()).thenReturn({ stdout: 'cwd' })
-    expect(fileHelpers.fetchGitRoot()).toEqual({stdout: 'cwd'})
+    td.when(cwd()).thenReturn({ stdout: 'fish' })
+    expect(fileHelpers.fetchGitRoot()).toEqual({stdout: 'fish'})
   })
 
   it('can get a file listing', async () => {

--- a/test/helpers/files.test.ts
+++ b/test/helpers/files.test.ts
@@ -29,9 +29,7 @@ describe('File Helpers', () => {
     const spawnSync = td.replace(childProcess, 'spawnSync')
     td.when(cwd()).thenReturn({ stdout: 'fish' })
     td.when(
-      spawnSync('git', ['rev-parse', '--show-toplevel'], {
-        maxBuffer: SPAWNPROCESSBUFFERSIZE,
-      }),
+      spawnSync('git', ['rev-parse', '--show-toplevel'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: 'gitRoot' })
 
     expect(fileHelpers.fetchGitRoot()).toBe('gitRoot')
@@ -41,7 +39,7 @@ describe('File Helpers', () => {
     const cwd = td.replace(process, 'cwd')
     td.replace(childProcess, 'spawnSync')
     td.when(cwd()).thenReturn({ stdout: 'cwd' })
-    expect(fileHelpers.fetchGitRoot()).toEqual({ stdout: 'cwd' })
+    expect(fileHelpers.fetchGitRoot()).toEqual({stdout: 'cwd'})
   })
 
   it('can get a file listing', async () => {
@@ -54,22 +52,12 @@ describe('File Helpers', () => {
       }
     })
     expect(
-      await fileHelpers.getFileListing('.', {
-        flags: '',
-        verbose: 'true',
-        slug: '',
-        upstream: '',
-      }),
+      await fileHelpers.getFileListing('.', { flags: '', verbose: 'true', slug: '',upstream: '' }),
     ).toBe(files.join('\n'))
   })
 
   it('can get a file listing with a file filter', async () => {
-    const files = [
-      'npm-shrinkwrap.json',
-      'package.json',
-      'package-lock.json',
-      'src/file.js',
-    ]
+    const files = ['npm-shrinkwrap.json', 'package.json', 'package-lock.json', 'src/file.js']
     td.replace(childProcess, 'spawnSync', () => {
       return {
         stdout: files.join('\n'),
@@ -123,12 +111,7 @@ describe('File Helpers', () => {
   })
 
   it('can get a file listing with a file filter and prefix', async () => {
-    const files = [
-      'npm-shrinkwrap.json',
-      'package.json',
-      'package-lock.json',
-      'src/file.js',
-    ]
+    const files = ['npm-shrinkwrap.json', 'package.json', 'package-lock.json', 'src/file.js']
     td.replace(childProcess, 'spawnSync', () => {
       return {
         stdout: files.join('\n'),
@@ -206,8 +189,9 @@ describe('File Helpers', () => {
       )
     })
     it('can read a coverage report file', async () => {
+
       mock({
-        'test-coverage-file.xml': 'I am test coverage data',
+        'test-coverage-file.xml': 'I am test coverage data'
       })
 
       const reportContents = await fileHelpers.readCoverageFile(
@@ -218,13 +202,15 @@ describe('File Helpers', () => {
     })
 
     it('throws when unable to read a coverage file', async () => {
+
       mock({
-        'test-coverage-file.xml': 'I am test coverage data',
+        'test-coverage-file.xml': 'I am test coverage data'
       })
 
-      await expect(
-        fileHelpers.readCoverageFile('.', 'test-no-coverage-file.xml'),
-      ).rejects.toThrowError(/no such file or directory/)
+      await expect(fileHelpers.readCoverageFile(
+        '.',
+        'test-no-coverage-file.xml',
+      )).rejects.toThrowError(/no such file or directory/)
     })
 
     it('can return a list of coverage files', async () => {
@@ -238,25 +224,17 @@ describe('File Helpers', () => {
       expect(results).not.toContain('codecov.exe')
 
       expect(results).toContain('test/fixtures/other/fake.codecov.txt')
-      expect(results).toContain(
-        'test/fixtures/codecov_demobox_2023-02-27_01-03-34.cobertura.xml',
-      )
+      expect(results).toContain('test/fixtures/codecov_demobox_2023-02-27_01-03-34.cobertura.xml')
     })
 
     it('can return a list of coverage files with a pattern', async () => {
       expect(
         await fileHelpers.getCoverageFiles('.', ['coverage.txt']),
-      ).toStrictEqual([
-        'test/fixtures/coverage.txt',
-        'test/fixtures/other/coverage.txt',
-      ])
+      ).toStrictEqual(['test/fixtures/coverage.txt', 'test/fixtures/other/coverage.txt'])
     })
     it('can return a list of coverage files with a negated pattern', async () => {
       expect(
-        await fileHelpers.getCoverageFiles('.', [
-          'coverage.txt',
-          '!test/fixtures/other',
-        ]),
+        await fileHelpers.getCoverageFiles('.', ['coverage.txt', '!test/fixtures/other']),
       ).toStrictEqual(['test/fixtures/coverage.txt'])
     })
     describe('coverage file patterns', () => {
@@ -304,105 +282,63 @@ describe('File Helpers', () => {
     })
   })
 
-  describe('filterFilesAgainstBlockList()', () => {
-    const getPaths = () =>
-      fileHelpers.getCoverageFiles('.', fileHelpers.coverageFilePatterns())
-    it('works', async () => {
+  describe("filterFilesAgainstBlockList()", () => {
+    const getPaths = () => fileHelpers.getCoverageFiles(
+      '.',
+      fileHelpers.coverageFilePatterns(),
+    )
+    it("works", async () => {
       const paths = await getPaths()
 
-      expect(() =>
-        fileHelpers.filterFilesAgainstBlockList(paths, getBlocklist()),
-      ).not.toThrow()
+      expect(() => fileHelpers.filterFilesAgainstBlockList(paths, getBlocklist())).not.toThrow()
     })
 
-    it('returns the input array when passed an empty ignore array', async () => {
+    it("returns the input array when passed an empty ignore array", async () => {
       const paths = await getPaths()
       expect(fileHelpers.filterFilesAgainstBlockList(paths, [])).toEqual(paths)
     })
 
-    it('ignores an ignore filename', async () => {
-      expect(
-        fileHelpers.filterFilesAgainstBlockList(await getPaths(), [
-          'coverage-summary.json',
-        ]),
-      ).not.toContain(expect.stringContaining('coverage-summary.json'))
+    it("ignores an ignore filename", async () => {
+      expect(fileHelpers.filterFilesAgainstBlockList(await getPaths(), ["coverage-summary.json"])).not.toContain(expect.stringContaining('coverage-summary.json'))
     })
 
-    it('ignores an ignore filename glob', async () => {
-      const foo = expect(
-        fileHelpers.filterFilesAgainstBlockList(await getPaths(), [
-          '**/coverage*',
-        ]),
-      ).not.toContainEqual(expect.stringMatching('/coverage'))
+    it("ignores an ignore filename glob", async () => {
+      const foo = expect(fileHelpers.filterFilesAgainstBlockList(await getPaths(), ["**/coverage*"])).not.toContainEqual(expect.stringMatching('/coverage'))
       console.log(foo)
     })
 
-    it('ignores an ignore filename globstar', async () => {
-      expect(
-        fileHelpers.filterFilesAgainstBlockList(await getPaths(), [
-          '**/other/*',
-        ]),
-      ).not.toContainEqual(expect.stringMatching('other'))
+    it("ignores an ignore filename globstar", async () => {
+      expect(fileHelpers.filterFilesAgainstBlockList(await getPaths(), ["**/other/*"])).not.toContainEqual(expect.stringMatching('other'))
     })
 
-    it('ignores shell scripts by default', async () => {
-      expect(
-        fileHelpers.filterFilesAgainstBlockList(
-          await getPaths(),
-          getBlocklist(),
-        ),
-      ).not.toContainEqual(expect.stringMatching('codecov.sh'))
+    it("ignores shell scripts by default", async () => {
+      expect(fileHelpers.filterFilesAgainstBlockList(await getPaths(), getBlocklist())).not.toContainEqual(expect.stringMatching('codecov.sh'))
     })
 
-    it('should ignore files ending with *.*js', async () => {
-      expect(
-        fileHelpers.filterFilesAgainstBlockList(
-          await getPaths(),
-          getBlocklist(),
-        ),
-      ).not.toContainEqual(expect.stringMatching('coverage.cjs'))
-      expect(
-        fileHelpers.filterFilesAgainstBlockList(
-          await getPaths(),
-          getBlocklist(),
-        ),
-      ).not.toContainEqual(expect.stringMatching('coverage.mjs'))
+    it("should ignore files ending with *.*js", async () => {
+      expect(fileHelpers.filterFilesAgainstBlockList(await getPaths(), getBlocklist())).not.toContainEqual(expect.stringMatching('coverage.cjs'))
+      expect(fileHelpers.filterFilesAgainstBlockList(await getPaths(), getBlocklist())).not.toContainEqual(expect.stringMatching('coverage.mjs'))
     })
 
-    it('should ignore files ending with *.js', async () => {
-      expect(
-        fileHelpers.filterFilesAgainstBlockList(
-          await getPaths(),
-          getBlocklist(),
-        ),
-      ).not.toContainEqual(expect.stringMatching('coverage.js'))
+    it("should ignore files ending with *.js", async () => {
+      expect(fileHelpers.filterFilesAgainstBlockList(await getPaths(), getBlocklist())).not.toContainEqual(expect.stringMatching('coverage.js'))
     })
 
-    it('ignores powershell scripts by default', async () => {
-      expect(
-        fileHelpers.filterFilesAgainstBlockList(
-          await getPaths(),
-          getBlocklist(),
-        ),
-      ).not.toContainEqual(expect.stringMatching('codecov.ps1'))
+    it("ignores powershell scripts by default", async () => {
+      expect(fileHelpers.filterFilesAgainstBlockList(await getPaths(), getBlocklist())).not.toContainEqual(expect.stringMatching('codecov.ps1'))
     })
-    it('ignores codecov configs by default', async () => {
-      expect(
-        fileHelpers.filterFilesAgainstBlockList(
-          await getPaths(),
-          getBlocklist(),
-        ),
-      ).not.toContainEqual(expect.stringMatching(/^\.?codecov\.ya?ml/))
+    it("ignores codecov configs by default", async () => {
+      expect(fileHelpers.filterFilesAgainstBlockList(await getPaths(), getBlocklist())).not.toContainEqual(expect.stringMatching(/^\.?codecov\.ya?ml/))
     })
 
-    it.each(['coverage.info', 'coverage.opencover.xml', 'gap-coverage.json'])(
-      'includes %s',
-      file => {
-        expect(
-          fileHelpers.filterFilesAgainstBlockList([file], getBlocklist()),
-        ).toContainEqual(expect.stringMatching(file))
-      },
-    )
+    it.each([
+      "coverage.info",
+      "coverage.opencover.xml",
+      "gap-coverage.json",
+    ])("includes %s", (file) => {
+      expect(fileHelpers.filterFilesAgainstBlockList([file], getBlocklist()))
+        .toContainEqual(expect.stringMatching(file))
+    })
   })
 
   it('can remove a file', () => {


### PR DESCRIPTION
### What? 

This PR updates the `fetchGitRoot` function in `files.ts` to not error when attempting to `runExternalProgram`. Explicitly, this change involves: 

1. Updating the return statement to return the `currentWorkingDirectory` if `gitRoot == ""` 
2. Updating the `catch (error)` block to log the error, and then returning the `currentWorkingDirectory` instead of `throw new Error`. 
3. Updating the associated test for `fetchGitRoot()` inside of `files.tests.ts` 