### PR TITLE
feat: add user agent to requests to the codecov api

### DIFF
--- a/src/helpers/web.ts
+++ b/src/helpers/web.ts
@@ -19,7 +19,7 @@ import { sleep } from './util'
 
 const maxRetries = 4
 const baseBackoffDelayMs = 1000 // Adjust this value based on your needs.
-export const userAgent: string = 'codecov-uploader/' + version
+export const userAgent: string = `codecov-uploader/${version}`
 
 /**
  *

--- a/src/helpers/web.ts
+++ b/src/helpers/web.ts
@@ -19,6 +19,7 @@ import { sleep } from './util'
 
 const maxRetries = 4
 const baseBackoffDelayMs = 1000 // Adjust this value based on your needs.
+export const userAgent: string = 'codecov-uploader/' + version
 
 /**
  *
@@ -209,9 +210,10 @@ export function generateRequestHeadersPOST(
     postURL,
   )
 
-  const headers = {
+  const headers: Record<string, string> = {
     'X-Upload-Token': token,
     'X-Reduced-Redundancy': 'false',
+    'User-Agent': userAgent,
   }
 
   return {
@@ -232,9 +234,10 @@ export function generateRequestHeadersPUT(
   envs: UploaderEnvs,
   args: UploaderArgs,
 ): IRequestHeaders {
-  const headers = {
+  const headers: Record<string, string> = {
     'Content-Type': 'text/plain',
     'Content-Encoding': 'gzip',
+    'User-Agent': userAgent,
   }
 
   return {

--- a/test/helpers/web.test.ts
+++ b/test/helpers/web.test.ts
@@ -17,12 +17,17 @@ import {
   populateBuildParams,
   uploadToCodecovPOST,
   uploadToCodecovPUT,
+  userAgent,
 } from '../../src/helpers/web'
 import { IServiceParams, PostResults, UploaderArgs, UploaderEnvs } from '../../src/types.js'
 import { createEmptyArgs } from '../test_helpers'
 
 import * as utilModule from '../../src/helpers/util'
+import { IncomingHttpHeaders } from 'undici/types/header'
 
+function hasUserAgent(headers: IncomingHttpHeaders | string[]): headers is IncomingHttpHeaders {
+  return "User-Agent" in headers
+}
 
 describe('Web Helpers', () => {
   let uploadURL: string
@@ -544,6 +549,13 @@ describe('generateRequestHeadersPOST()', () => {
         'G',
       )}&token=134&slug=testOrg/testUploader`,
     )
+
+    const headers = requestHeaders.options.headers!
+    expect(hasUserAgent(headers)).toEqual(true)
+    if (hasUserAgent(headers)) {
+      expect(headers['User-Agent']).toEqual(userAgent)
+    }
+
     expect(typeof requestHeaders.options.body).toEqual('undefined')
     expect(typeof requestHeaders.agent).toEqual('undefined')
   })
@@ -566,6 +578,12 @@ describe('generateRequestHeadersPOST()', () => {
       )}&token=134&slug=testOrg/testUploader`,
     )
 
+    const headers = requestHeaders.options.headers!
+    expect(hasUserAgent(headers)).toEqual(true)
+    if (hasUserAgent(headers)) {
+      expect(headers['User-Agent']).toEqual(userAgent)
+    }
+
     expect(typeof requestHeaders.options.body).toEqual('undefined')
     expect(requestHeaders.agent).toBeInstanceOf(ProxyAgent)
   })
@@ -585,6 +603,13 @@ describe('generateRequestHeadersPUT()', () => {
     )
 
     expect(requestHeaders.url.href).toEqual('https://localhost.local/')
+
+    const headers = requestHeaders.options.headers!
+    expect(hasUserAgent(headers)).toEqual(true)
+    if (hasUserAgent(headers)) {
+      expect(headers['User-Agent']).toEqual(userAgent)
+    }
+
     expect(requestHeaders.options.body).toEqual("I'm a coverage report!")
     expect(typeof requestHeaders.agent).toEqual('undefined')
   })
@@ -600,6 +625,13 @@ describe('generateRequestHeadersPUT()', () => {
     )
 
     expect(requestHeaders.url.href).toEqual('https://localhost.local/')
+
+    const headers = requestHeaders.options.headers!
+    expect(hasUserAgent(headers)).toEqual(true)
+    if (hasUserAgent(headers)) {
+      expect(headers['User-Agent']).toEqual(userAgent)
+    }
+
     expect(requestHeaders.options.body).toEqual("I'm a coverage report!")
     expect(requestHeaders.agent).toBeInstanceOf(ProxyAgent)
   })


### PR DESCRIPTION
add `User-Agent: codecov-uploader/{version}` header to outgoing requests to the codecov api so we can track API usage compared to gazebo and `codecov-cli` or by uploader version

it appears we send a `package` param to a legacy upload endpoint with this information already which can tell us what proportion of that endpoint's traffic is from this uploader, but setting a user agent across the board tells us for all endpoints, or what proportion of overall API traffic is from this uploader