### PR TITLE
feat: add useCWD option to args

### DIFF
--- a/HELPFILE
+++ b/HELPFILE
@@ -57,6 +57,8 @@ Options:
                                 through                   [string] [default: ""]
   -u, --url                     Change the upload host (Enterprise use)
                                         [string] [default: "https://codecov.io"]
+      --useCWD, --uc            Use the current working directory instead of the
+                                git root [boolean] [default: false]
   -v, --verbose                 Run with verbose logging               [boolean]
   -X, --feature                 Toggle functionalities. Separate multiple ones
                                 by comma: -X network,search

--- a/HELPFILE
+++ b/HELPFILE
@@ -57,7 +57,7 @@ Options:
                                 through                   [string] [default: ""]
   -u, --url                     Change the upload host (Enterprise use)
                                         [string] [default: "https://codecov.io"]
-      --useCWD, --uc            Use the current working directory instead of the
+      --useCwd, --uc            Use the current working directory instead of the
                                 git root [boolean] [default: false]
   -v, --verbose                 Run with verbose logging               [boolean]
   -X, --feature                 Toggle functionalities. Separate multiple ones

--- a/src/helpers/cli.ts
+++ b/src/helpers/cli.ts
@@ -192,7 +192,7 @@ const args: ICLIArgument[] = [
   },
   {
     alias: 'uc',
-    name: 'useCWD',
+    name: 'useCwd',
     type: 'boolean',
     default: false,
     description: 'Use the current working directory instead of the git root',

--- a/src/helpers/cli.ts
+++ b/src/helpers/cli.ts
@@ -191,6 +191,13 @@ const args: ICLIArgument[] = [
     default: 'https://codecov.io',
   },
   {
+    alias: 'uc',
+    name: 'useCWD',
+    type: 'boolean',
+    default: false,
+    description: 'Use the current working directory instead of the git root',
+  },
+  {
     alias: 'v',
     name: 'verbose',
     type: 'boolean',

--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -221,11 +221,11 @@ export async function getCoverageFiles(
   })
 }
 
-export function fetchGitRoot(useCWD: boolean): string {
+export function fetchGitRoot(useCwd: boolean): string {
   const currentWorkingDirectory = process.cwd()
   try {
     const gitRoot = runExternalProgram('git', ['rev-parse', '--show-toplevel'])
-    return (gitRoot != "" && !useCWD ? gitRoot : currentWorkingDirectory)
+    return (gitRoot != "" && !useCwd ? gitRoot : currentWorkingDirectory)
   } catch (error) {
     info(`Error fetching git root. Defaulting to ${currentWorkingDirectory}. Please try using the -R flag. ${error}`)
     return currentWorkingDirectory

--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -221,11 +221,11 @@ export async function getCoverageFiles(
   })
 }
 
-export function fetchGitRoot(): string {
+export function fetchGitRoot(useCWD: boolean): string {
   const currentWorkingDirectory = process.cwd()
   try {
     const gitRoot = runExternalProgram('git', ['rev-parse', '--show-toplevel'])
-    return (gitRoot != "" ? gitRoot : currentWorkingDirectory)
+    return (gitRoot != "" && !useCWD ? gitRoot : currentWorkingDirectory)
   } catch (error) {
     info(`Error fetching git root. Defaulting to ${currentWorkingDirectory}. Please try using the -R flag. ${error}`)
     return currentWorkingDirectory

--- a/src/helpers/web.ts
+++ b/src/helpers/web.ts
@@ -19,7 +19,7 @@ import { sleep } from './util'
 
 const maxRetries = 4
 const baseBackoffDelayMs = 1000 // Adjust this value based on your needs.
-export const userAgent: string = `codecov-uploader/${version}`
+export const userAgent = `codecov-uploader/${version}`
 
 /**
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ function dryRun(
  * @param {boolean} args.clean Move discovered coverage reports to the trash
  * @param {string} args.feature Toggle features
  * @param {string} args.source Track wrappers of the uploader
+ * @param {string} args.useCWD Use current working directory as the automatically detected project root
  */
 export async function main(
   args: UploaderArgs,
@@ -135,7 +136,7 @@ export async function main(
 
   // #endregion
   // #region == Step 2: detect if we are in a git repo
-  const projectRoot = args.rootDir || fetchGitRoot()
+  const projectRoot = args.rootDir || fetchGitRoot(args.useCWD || false)
   if (projectRoot === '') {
     info(
       '=> No git repo detected. Please use the -R flag if the below detected directory is not correct.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ function dryRun(
  * @param {boolean} args.clean Move discovered coverage reports to the trash
  * @param {string} args.feature Toggle features
  * @param {string} args.source Track wrappers of the uploader
- * @param {string} args.useCWD Use current working directory as the automatically detected project root
+ * @param {string} args.useCwd Use current working directory as the automatically detected project root
  */
 export async function main(
   args: UploaderArgs,
@@ -136,7 +136,7 @@ export async function main(
 
   // #endregion
   // #region == Step 2: detect if we are in a git repo
-  const projectRoot = args.rootDir || fetchGitRoot(args.useCWD || false)
+  const projectRoot = args.rootDir || fetchGitRoot(args.useCwd || false)
   if (projectRoot === '') {
     info(
       '=> No git repo detected. Please use the -R flag if the below detected directory is not correct.',

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,9 +13,9 @@ export interface UploaderArgs {
   flags: string | string[] // Flag the upload to group coverage metrics
   fullReport?: string // Specify the path to a previously uploaded Codecov report
   gcov?: string // Run with gcov support
-  gcovArgs?:  string | string[] // Extra arguments to pass to gcov
-  gcovIgnore?:  string | string[] // Paths to ignore during gcov gathering
-  gcovInclude?:  string | string[] // Paths to include during gcov gathering
+  gcovArgs?: string | string[] // Extra arguments to pass to gcov
+  gcovIgnore?: string | string[] // Paths to ignore during gcov gathering
+  gcovInclude?: string | string[] // Paths to include during gcov gathering
   gcovExecutable?: string // gcov executable to run.
   name?: string // Custom defined name of the upload. Visible in Codecov UI
   networkFilter?: string // Specify a prefix on the files listed in the network section of the Codecov report. Useful for upload-specific path fixing
@@ -34,7 +34,7 @@ export interface UploaderArgs {
   token?: string // Codecov upload token
   upstream: string // Upstream proxy to connect to
   url?: string // Change the upload host (Enterprise use)
-  useCWD?: boolean
+  useCwd?: boolean
   verbose?: string // Run with verbose logging
   xcode?: string // Run with xcode support
   xcodeArchivePath?: string // Specify the xcode archive path. Likely specified as the -resultBundlePath and should end in .xcresult

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface UploaderArgs {
   token?: string // Codecov upload token
   upstream: string // Upstream proxy to connect to
   url?: string // Change the upload host (Enterprise use)
+  useCWD?: boolean
   verbose?: string // Run with verbose logging
   xcode?: string // Run with xcode support
   xcodeArchivePath?: string // Specify the xcode archive path. Likely specified as the -resultBundlePath and should end in .xcresult

--- a/test/helpers/coveragepy.test.ts
+++ b/test/helpers/coveragepy.test.ts
@@ -12,7 +12,7 @@ describe('generateCoveragePyFile()', () => {
 
     it('should run when coveragepy is asked for', async () => {
         const fixturesCoveragePyDir = path.join(
-            fileHelpers.fetchGitRoot(),
+            fileHelpers.fetchGitRoot(false),
             'test/fixtures/coveragepy',
         )
 
@@ -50,7 +50,7 @@ describe('generateCoveragePyFile()', () => {
 
     it('should return a log when there are no dotcoverage files', async () => {
         const fixturesYamlDir = path.join(
-            fileHelpers.fetchGitRoot(),
+            fileHelpers.fetchGitRoot(false),
             'test/fixtures/yaml',
         )
 

--- a/test/helpers/files.test.ts
+++ b/test/helpers/files.test.ts
@@ -32,14 +32,26 @@ describe('File Helpers', () => {
       spawnSync('git', ['rev-parse', '--show-toplevel'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: Buffer.from('gitRoot') })
 
-    expect(fileHelpers.fetchGitRoot()).toBe('gitRoot')
+    expect(fileHelpers.fetchGitRoot(false)).toBe('gitRoot')
   })
 
   it('returns cwd when it cannot fetch the git root', () => {
     const cwd = td.replace(process, 'cwd')
     td.replace(childProcess, 'spawnSync')
     td.when(cwd()).thenReturn('fish')
-    expect(fileHelpers.fetchGitRoot()).toEqual('fish')
+    expect(fileHelpers.fetchGitRoot(false)).toEqual('fish')
+  })
+
+  it('returns cwd when its input is true even if it can fetch the git root', () => {
+    const cwd = td.replace(process, 'cwd')
+    const spawnSync = td.replace(childProcess, 'spawnSync')
+    td.when(cwd()).thenReturn('fish')
+    td.when(
+      spawnSync('git', ['rev-parse', '--show-toplevel'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
+    ).thenReturn({ stdout: Buffer.from('gitRoot') })
+
+    expect(fileHelpers.fetchGitRoot(true)).toEqual('fish')
+
   })
 
   it('can get a file listing', async () => {

--- a/test/helpers/files.test.ts
+++ b/test/helpers/files.test.ts
@@ -45,12 +45,12 @@ describe('File Helpers', () => {
   it('returns cwd when its input is true even if it can fetch the git root', () => {
     const cwd = td.replace(process, 'cwd')
     const spawnSync = td.replace(childProcess, 'spawnSync')
-    td.when(cwd()).thenReturn('fish')
+    td.when(cwd()).thenReturn('CWD')
     td.when(
       spawnSync('git', ['rev-parse', '--show-toplevel'], { maxBuffer: SPAWNPROCESSBUFFERSIZE }),
     ).thenReturn({ stdout: Buffer.from('gitRoot') })
 
-    expect(fileHelpers.fetchGitRoot(true)).toEqual('fish')
+    expect(fileHelpers.fetchGitRoot(true)).toEqual('CWD')
 
   })
 

--- a/test/helpers/token.test.ts
+++ b/test/helpers/token.test.ts
@@ -8,11 +8,11 @@ import { createEmptyArgs } from '../test_helpers'
 
 describe('Get tokens', () => {
   const fixturesDir = path.join(
-    fileHelpers.fetchGitRoot(),
+    fileHelpers.fetchGitRoot(false),
     'test/fixtures/yaml',
   )
   const invalidFixturesDir = path.join(
-    fileHelpers.fetchGitRoot(),
+    fileHelpers.fetchGitRoot(false),
     'test/fixtures/invalid_yaml',
   )
 


### PR DESCRIPTION
This option is being added to allow users to manually decide to use the current working directory instead of the git root when fetching the git root automatically.