### PR TITLE
chore(ci): add test-alpine job

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -307,7 +307,7 @@ jobs:
       - name: Install git
         run: |
           apk update
-          apk add git
+          apk add git squid
       - name: Checkout
         uses: actions/checkout@v4
       - uses: actions/download-artifact@v3

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -181,6 +181,7 @@ jobs:
   test-alpine:
     runs-on: ubuntu-latest
     container: alpine:3.19.0@sha256:51b67269f354137895d43f3b3d810bfacd3945438e94dc5ac55fdac340352f48
+    needs: build-alpine
     steps:
       - name: Install git
         run: |

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -9,12 +9,8 @@ on:
 # Remaining circleci jobs to port
 # - build-aarch64:
 # - test-alpine-proxy:
-# - test-alpine-without-git:
 # - test-aarch64:
 # - test-aarch64-without-git:
-# - test-linux-without-git:
-# - test-macos-without-git:
-# - test-windows-without-git:
 # - review:
 # - deploy:
 # - release:
@@ -149,6 +145,37 @@ jobs:
           path: |
             output_linux.txt
 
+  test-linux-without-git:
+    runs-on: ubuntu-latest
+    needs: test-linux
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+      - name: Remove .git directory
+        run: rm -rf .git
+      - name: Remove test coverage files
+        run: rm -rf *.coverage.txt coverage-report-test.json test/fixtures || echo
+      - name: Update exec permission
+        run: chmod u+x out/codecov-linux
+      - name: Run Linux binary (dry run)
+        run: |
+          out/codecov-linux -F linux-without-git -d -Z | tee -a output_linux_without_git.txt
+      - name: Run Linux binary (upload)
+        run: |
+          out/codecov-linux -F linux-without-git -Z -t ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          path: |
+            output_linux_without_git.txt
+
   test-macos:
     runs-on: macos-latest
     needs: build-linux-and-osx
@@ -177,6 +204,34 @@ jobs:
           if-no-files-found: error
           path: |
             output_osx.txt
+
+  test-macos-without-git:
+    runs-on: macos-latest
+    needs: test-macos
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+      - name: Remove .git directory
+        run: rm -rf .git
+      - name: Remove test coverage files
+        run: rm -rf *.coverage.txt coverage-report-test.json test/fixtures || echo
+      - name: Update exec permission
+        run: chmod u+x out/codecov-macos
+      - name: Run MacOS binary (dry-run)
+        run: |
+          out/codecov-macos -F macos-without-git -v -d -Z -t ${{ secrets.CODECOV_TOKEN }} | tee -a output_osx_without_git.txt
+      - name: Run MacOS binary (upload)
+        run: |
+          out/codecov-macos -F macos-without-git -v -Z -t ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          path: |
+            output_osx_without_git.txt
 
   test-alpine:
     runs-on: ubuntu-latest
@@ -211,6 +266,41 @@ jobs:
           path: |
             output_alpine.txt
 
+  test-alpine-without-git:
+    runs-on: ubuntu-latest
+    container: alpine:3.19.0@sha256:51b67269f354137895d43f3b3d810bfacd3945438e94dc5ac55fdac340352f48
+    needs: test-alpine
+    steps:
+      - name: Install git
+        run: |
+          apk update
+          apk add git
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+      - name: Remove .git directory
+        run: rm -rf .git
+      - name: Remove test coverage files
+        run: rm -rf *.coverage.txt coverage-report-test.json test/fixtures || echo
+      - name: Update exec permission
+        run: chmod u+x out/codecov-alpine
+      - name: Run Alpine binary -f (dry run)
+        run: |
+          NODE_DEBUG=vm out/codecov-alpine -v -f ./coverage-alpine/cobertura-coverage.xml -F alpine-without-git -d -Z -t ${{ secrets.CODECOV_TOKEN }} >> output_alpine_without_git.txt
+      - name: Run Alpine binary auto-detect (dry run)
+        run: |
+          out/codecov-alpine -F alpine-without-git -v -d -Z -t ${{ secrets.CODECOV_TOKEN }} >> output_alpine_without_git.txt
+      - name: Run Alpine binary (upload)
+        run: out/codecov-alpine -F alpine-without-git -v -Z -t ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          path: |
+            output_alpine_without_git.txt
+
   test-windows:
     runs-on: windows-latest
     needs: build-windows
@@ -244,3 +334,75 @@ jobs:
           if-no-files-found: error
           path: |
             output_win.txt
+
+  test-windows-without-git:
+    runs-on: windows-latest
+    needs: test-windows
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+      - name: Remove .git directory
+        run: del -Recurse -Force .git
+      - name: Remove test coverage files
+        run: |
+          Remove-Item -Recurse -Force *.coverage.txt;  echo "ok"
+          Remove-Item -Recurse -Force test/fixtures; echo "ok"
+      - name: Run Windows binary -f (dry-run)
+        run: |
+          dir .
+          attrib .\coverage\cobertura-coveage.xml
+          .\out\codecov.exe -f .\coverage\cobertura-coverage.xml -F windows-without-git -d -Z -v -t ${{ secrets.CODECOV_TOKEN }} | tee output_win_without_git.txt
+        shell: cmd
+      - name: Run Windows binary auto-detect (dry-run)
+        run: |
+          .\out\codecov.exe -F windows-without-git -v -d -Z -t ${{ secrets.CODECOV_TOKEN }} | tee -a output_win_without_git.txt
+        shell: cmd
+      - name: Run Windows binary (upload)
+        run: |
+          .\out\codecov.exe -F windows-without-git -v -Z -t ${{ secrets.CODECOV_TOKEN }}
+        shell: cmd
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          path: |
+            output_win_without_git.txt
+
+  review:
+    runs-on: ubuntu-latest
+    needs:
+      - test-alpine-without-git
+      - test-linux-without-git
+      - test-macos-without-git
+      - test-windows-without-git
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+      - name: List files
+        run: tree
+      - name: Cat output_alpine.txt
+        run: cat output_alpine.txt
+      - name: Cat output_alpine_without_git.txt
+        run: cat output_alpine_without_git.txt
+      - name: Cat output_linux.txt
+        run: cat output_linux.txt
+      - name: Cat output_linux_without_git.txt
+        run: cat output_linux_without_git.txt
+      - name: Cat output_macos.txt
+        run: cat output_macos.txt
+      - name: Cat output_macos_without_git.txt
+        run: cat output_macos_without_git.txt
+      - name: Cat output_windows.txt
+        run: cat output_windows.txt
+      - name: Cat output_windows_without_git.txt
+        run: cat output_windows_without_git.txt

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -437,7 +437,7 @@ jobs:
         run: cat output_osx.txt
       - name: Cat output_osx_without_git.txt
         run: cat output_osx_without_git.txt
-      - name: Cat output_windows.txt
-        run: cat output_windows.txt
-      - name: Cat output_windows_without_git.txt
-        run: cat output_windows_without_git.txt
+      - name: Cat output_win.txt
+        run: cat output_win.txt
+      - name: Cat output_win_without_git.txt
+        run: cat output_win_without_git.txt

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -429,10 +429,10 @@ jobs:
         run: cat output_linux.txt
       - name: Cat output_linux_without_git.txt
         run: cat output_linux_without_git.txt
-      - name: Cat output_macos.txt
-        run: cat output_macos.txt
-      - name: Cat output_macos_without_git.txt
-        run: cat output_macos_without_git.txt
+      - name: Cat output_osx.txt
+        run: cat output_osx.txt
+      - name: Cat output_osx_without_git.txt
+        run: cat output_osx_without_git.txt
       - name: Cat output_windows.txt
         run: cat output_windows.txt
       - name: Cat output_windows_without_git.txt

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -196,14 +196,9 @@ jobs:
         run: rm -rf *.coverage.txt coverage-report-test.json test/fixtures || echo
       - name: Update exec permission
         run: chmod u+x out/codecov-alpine
-      - name: ls
-        run: |
-          pwd
-          ls
-          find . -name 'cobertura-coverage.xml'
       - name: Run Alpine binary -f (dry run)
         run: |
-          NODE_DEBUG=vm out/codecov-alpine -v -f /root/project/coverage-alpine/cobertura-coverage.xml -F alpine -d -Z -t ${{ secrets.CODECOV_TOKEN }} >> output_alpine.txt
+          NODE_DEBUG=vm out/codecov-alpine -v -f ./coverage-alpine/cobertura-coverage.xml -F alpine -d -Z -t ${{ secrets.CODECOV_TOKEN }} >> output_alpine.txt
       - name: Run Alpine binary auto-detect (dry run)
         run: |
           out/codecov-alpine -F alpine -v -d -Z -t ${{ secrets.CODECOV_TOKEN }} >> output_alpine.txt

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -196,8 +196,6 @@ jobs:
         run: rm -rf *.coverage.txt coverage-report-test.json test/fixtures || echo
       - name: Update exec permission
         run: chmod u+x out/codecov-alpine
-      - name: node version
-        run: node -v
       - name: Run Alpine binary -f (dry run)
         run: |
           NODE_DEBUG=vm out/codecov-alpine -v -f /root/project/coverage-alpine/cobertura-coverage.xml -F alpine -d -Z -t ${{ secrets.CODECOV_TOKEN }} >> output_alpine.txt

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -145,7 +145,7 @@ jobs:
 
   test-linux-without-git:
     runs-on: ubuntu-latest
-    needs: test-linux
+    needs: build-linux-and-osx
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -205,7 +205,7 @@ jobs:
 
   test-macos-without-git:
     runs-on: macos-latest
-    needs: test-macos
+    needs: build-linux-and-osx
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -267,7 +267,7 @@ jobs:
   test-alpine-without-git:
     runs-on: ubuntu-latest
     container: alpine:3.19.0@sha256:51b67269f354137895d43f3b3d810bfacd3945438e94dc5ac55fdac340352f48
-    needs: test-alpine
+    needs: build-alpine
     steps:
       - name: Install git
         run: |
@@ -302,7 +302,7 @@ jobs:
   test-alpine-proxy:
     runs-on: ubuntu-latest
     container: alpine:3.19.0@sha256:51b67269f354137895d43f3b3d810bfacd3945438e94dc5ac55fdac340352f48
-    needs: test-alpine
+    needs: build-alpine
     steps:
       - name: Install git
         run: |
@@ -367,7 +367,7 @@ jobs:
 
   test-windows-without-git:
     runs-on: windows-latest
-    needs: test-windows
+    needs: build-windows
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -404,10 +404,14 @@ jobs:
   review:
     runs-on: ubuntu-latest
     needs:
+      - test-alpine
       - test-alpine-proxy
       - test-alpine-without-git
+      - test-linux
       - test-linux-without-git
+      - test-macos
       - test-macos-without-git
+      - test-windows
       - test-windows-without-git
     steps:
       - name: Checkout

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -194,14 +194,16 @@ jobs:
           name: artifact
       - name: Remove test coverage files
         run: rm -rf *.coverage.txt coverage-report-test.json test/fixtures || echo
+      - name: Update exec permission
+        run: chmod u+x out/codecov-alpine
       - name: Run Alpine binary -f (dry run)
         run: |
-          NODE_DEBUG=vm out/codecov-alpine -v -f /root/project/coverage-alpine/cobertura-coverage.xml -F alpine -d -Z -e CIRCLE_BRANCH -t ${{ secrets.CODECOV_TOKEN }} >> output_alpine.txt
+          NODE_DEBUG=vm out/codecov-alpine -v -f /root/project/coverage-alpine/cobertura-coverage.xml -F alpine -d -Z -t ${{ secrets.CODECOV_TOKEN }} >> output_alpine.txt
       - name: Run Alpine binary auto-detect (dry run)
         run: |
-          out/codecov-alpine -F alpine -v -d -Z -e CIRCLE_BRANCH -t ${{ secrets.CODECOV_TOKEN }} >> output_alpine.txt
+          out/codecov-alpine -F alpine -v -d -Z -t ${{ secrets.CODECOV_TOKEN }} >> output_alpine.txt
       - name: Run Alpine binary (upload)
-        run: out/codecov-alpine -F alpine -v -Z -e CIRCLE_BRANCH -t ${{ secrets.CODECOV_TOKEN }}
+        run: out/codecov-alpine -F alpine -v -Z -t ${{ secrets.CODECOV_TOKEN }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -196,6 +196,11 @@ jobs:
         run: rm -rf *.coverage.txt coverage-report-test.json test/fixtures || echo
       - name: Update exec permission
         run: chmod u+x out/codecov-alpine
+      - name: ls
+        run: |
+          pwd
+          ls
+          find . -name 'cobertura-coverage.xml'
       - name: Run Alpine binary -f (dry run)
         run: |
           NODE_DEBUG=vm out/codecov-alpine -v -f /root/project/coverage-alpine/cobertura-coverage.xml -F alpine -d -Z -t ${{ secrets.CODECOV_TOKEN }} >> output_alpine.txt

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Create pkg-cache directory and copy static NodeJS binary
         run: |
           mkdir -p ~/.pkg-cache/v2.6
-          cp node ~/.pkg-cache/v2.6/fetched-v16.2.0-alpine-x64
+          cp node ~/.pkg-cache/v2.6/fetched-v14.0.0-alpine-x64
       - name: Remove downloaded binary and run tests
         run: |
           rm -rf node

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -8,10 +8,8 @@ on:
 
 # Remaining circleci jobs to port
 # - build-aarch64:
-# - test-alpine-proxy:
 # - test-aarch64:
 # - test-aarch64-without-git:
-# - review:
 # - deploy:
 # - release:
 
@@ -301,6 +299,38 @@ jobs:
           path: |
             output_alpine_without_git.txt
 
+  test-alpine-proxy:
+    runs-on: ubuntu-latest
+    container: alpine:3.19.0@sha256:51b67269f354137895d43f3b3d810bfacd3945438e94dc5ac55fdac340352f48
+    needs: test-alpine
+    steps:
+      - name: Install git
+        run: |
+          apk update
+          apk add git
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+      - name: Start squid
+        run: squid
+      - name: Remove test coverage files
+        run: rm -rf *.coverage.txt coverage-report-test.json test/fixtures || echo
+      - name: Update exec permission
+        run: chmod u+x out/codecov-alpine
+      - name: Run Alpine binary auto-detect (dry run)
+        run: |
+          out/codecov-alpine -U http://localhost:3128 -F alpine-without-git -v -d -Z -t ${{ secrets.CODECOV_TOKEN }} >> output_alpine_proxy.txt
+      - name: Run Alpine binary (upload)
+        run: out/codecov-alpine -U http://localhost:3128 -F alpine-without-git -v -Z -t ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          path: |
+            output_alpine_proxy.txt
+
   test-windows:
     runs-on: windows-latest
     needs: build-windows
@@ -374,6 +404,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     needs:
+      - test-alpine-proxy
       - test-alpine-without-git
       - test-linux-without-git
       - test-macos-without-git

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -8,7 +8,6 @@ on:
 
 # Remaining circleci jobs to port
 # - build-aarch64:
-# - test-alpine:
 # - test-alpine-proxy:
 # - test-alpine-without-git:
 # - test-aarch64:
@@ -48,7 +47,7 @@ jobs:
 
   build-alpine:
     runs-on: ubuntu-latest
-    container: alpine:3.18.4@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978
+    container: alpine:3.19.0@sha256:51b67269f354137895d43f3b3d810bfacd3945438e94dc5ac55fdac340352f48
     needs: build-linux-and-osx
     steps:
       - name: Checkout
@@ -178,6 +177,36 @@ jobs:
           if-no-files-found: error
           path: |
             output_osx.txt
+
+  test-alpine:
+    runs-on: ubuntu-latest
+    container: alpine:3.19.0@sha256:51b67269f354137895d43f3b3d810bfacd3945438e94dc5ac55fdac340352f48
+    steps:
+      - name: Install git
+        run: |
+          apk update
+          apk add git
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+      - name: Remove test coverage files
+        run: rm -rf *.coverage.txt coverage-report-test.json test/fixtures || echo
+      - name: Run Alpine binary -f (dry run)
+        run: |
+          NODE_DEBUG=vm out/codecov-alpine -v -f /root/project/coverage-alpine/cobertura-coverage.xml -F alpine -d -Z -e CIRCLE_BRANCH -t ${{ secrets.CODECOV_TOKEN }} >> output_alpine.txt
+      - name: Run Alpine binary auto-detect (dry run)
+        run: |
+          out/codecov-alpine -F alpine -v -d -Z -e CIRCLE_BRANCH -t ${{ secrets.CODECOV_TOKEN }} >> output_alpine.txt
+      - name: Run Alpine binary (upload)
+        run: out/codecov-alpine -F alpine -v -Z -e CIRCLE_BRANCH -t ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          path: |
+            output_alpine.txt
 
   test-windows:
     runs-on: windows-latest

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Create pkg-cache directory and copy static NodeJS binary
         run: |
           mkdir -p ~/.pkg-cache/v2.6
-          cp node ~/.pkg-cache/v2.6/fetched-v14.0.0-alpine-x64
+          cp node ~/.pkg-cache/v2.6/fetched-v16.2.0-alpine-x64
       - name: Remove downloaded binary and run tests
         run: |
           rm -rf node
@@ -196,6 +196,8 @@ jobs:
         run: rm -rf *.coverage.txt coverage-report-test.json test/fixtures || echo
       - name: Update exec permission
         run: chmod u+x out/codecov-alpine
+      - name: node version
+        run: node -v
       - name: Run Alpine binary -f (dry run)
         run: |
           NODE_DEBUG=vm out/codecov-alpine -v -f /root/project/coverage-alpine/cobertura-coverage.xml -F alpine -d -Z -t ${{ secrets.CODECOV_TOKEN }} >> output_alpine.txt

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12,7 +12,7 @@
         "fast-glob": "3.3.2",
         "js-yaml": "4.1.0",
         "snake-case": "3.0.4",
-        "undici": "6.2.1",
+        "undici": "5.28.2",
         "validator": "13.11.0",
         "yargs": "17.7.2"
       },
@@ -8388,14 +8388,14 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.2.1.tgz",
-      "integrity": "sha512-7Wa9thEM6/LMnnKtxJHlc8SrTlDmxqJecgz1iy8KlsN0/iskQXOQCuPkrZLXbElPaSw5slFFyKIKXyJ3UtbApw==",
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {
@@ -14917,9 +14917,9 @@
       "optional": true
     },
     "undici": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.2.1.tgz",
-      "integrity": "sha512-7Wa9thEM6/LMnnKtxJHlc8SrTlDmxqJecgz1iy8KlsN0/iskQXOQCuPkrZLXbElPaSw5slFFyKIKXyJ3UtbApw==",
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
       "requires": {
         "@fastify/busboy": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "fast-glob": "3.3.2",
     "js-yaml": "4.1.0",
     "snake-case": "3.0.4",
-    "undici": "6.2.1",
+    "undici": "5.28.2",
     "validator": "13.11.0",
     "yargs": "17.7.2"
   },


### PR DESCRIPTION
Adds most of the `test-` jobs with the exception of `aarch64`. Also adds the `release job`